### PR TITLE
Allow empty body

### DIFF
--- a/src/Request/RequestInterface.php
+++ b/src/Request/RequestInterface.php
@@ -18,5 +18,5 @@ interface RequestInterface
 
     public function uriParameters(): array;
 
-    public function body(): array;
+    public function body(): ?array;
 }

--- a/src/Transport/Json/AsyncJsonTransport.php
+++ b/src/Transport/Json/AsyncJsonTransport.php
@@ -64,7 +64,7 @@ final class AsyncJsonTransport implements TransportInterface
             ->withAddedHeader('Content-Type', 'application/json')
             ->withAddedHeader('Accept', 'application/json')
             ->withBody($this->streamFactory->createStream(
-                $body = json_encode($request->body())
+                null !== $request->body() ? json_encode($request->body()) : ''
             ));
 
         $httpPromise = $this->client->sendAsyncRequest($httpRequest);

--- a/src/Transport/Json/JsonTransport.php
+++ b/src/Transport/Json/JsonTransport.php
@@ -58,7 +58,7 @@ final class JsonTransport implements TransportInterface
             ->withAddedHeader('Content-Type', 'application/json')
             ->withAddedHeader('Accept', 'application/json')
             ->withBody($this->streamFactory->createStream(
-                $body = json_encode($request->body())
+                null !== $request->body() ? json_encode($request->body()) : ''
             ));
 
         $response = $this->client->sendRequest($httpRequest);

--- a/tests/Helper/Request/SampleRequest.php
+++ b/tests/Helper/Request/SampleRequest.php
@@ -11,9 +11,9 @@ class SampleRequest implements RequestInterface
     private string $method;
     private string $uri;
     private array $uriParameters;
-    private array $body;
+    private ?array $body;
 
-    public function __construct(string $method, string $uri, array $uriParameters, array $body)
+    public function __construct(string $method, string $uri, array $uriParameters, ?array $body)
     {
         $this->method = $method;
         $this->uri = $uri;
@@ -41,7 +41,7 @@ class SampleRequest implements RequestInterface
         return $this->uriParameters;
     }
 
-    public function body(): array
+    public function body(): ?array
     {
         return $this->body;
     }

--- a/tests/Unit/Transport/Json/AsyncJsonTransportTest.php
+++ b/tests/Unit/Transport/Json/AsyncJsonTransportTest.php
@@ -60,6 +60,27 @@ class AsyncJsonTransportTest extends TestCase
     }
 
     /** @test */
+    public function it_can_send_with_empty_body(): void
+    {
+        $request = new SampleRequest('GET', '/some-endpoint', [], null);
+        $this->client->addResponse(
+            $this->createResponse(200)
+                ->withAddedHeader('Content-Type', 'application/json')
+                ->withBody($this->createStream(json_encode($expectedResponse = ['response' => 'ok'])))
+        );
+
+        $actualResponse = wait(($this->transport)($request));
+        $sentRequest = $this->client->getLastRequest();
+
+        self::assertSame($expectedResponse, $actualResponse);
+        self::assertSame($request->method(), $sentRequest->getMethod());
+        self::assertSame($request->uri(), $sentRequest->getUri()->__toString());
+        self::assertSame('', $sentRequest->getBody()->__toString());
+        self::assertSame(['application/json'], $sentRequest->getHeader('Content-Type'));
+        self::assertSame(['application/json'], $sentRequest->getHeader('Accept'));
+    }
+
+    /** @test */
     public function it_can_handle_failure(): void
     {
         $request = new SampleRequest('GET', '/some-endpoint', [], ['hello' => 'world']);

--- a/tests/Unit/Transport/Json/JsonTransportTest.php
+++ b/tests/Unit/Transport/Json/JsonTransportTest.php
@@ -54,4 +54,25 @@ class JsonTransportTest extends TestCase
         self::assertSame(['application/json'], $sentRequest->getHeader('Content-Type'));
         self::assertSame(['application/json'], $sentRequest->getHeader('Accept'));
     }
+
+    /** @test */
+    public function it_can_send_with_empty_body(): void
+    {
+        $request = new SampleRequest('GET', '/some-endpoint', [], null);
+        $this->client->addResponse(
+            $this->createResponse(200)
+                ->withAddedHeader('Content-Type', 'application/json')
+                ->withBody($this->createStream(json_encode($expectedResponse = ['response' => 'ok'])))
+        );
+
+        $actualResponse = ($this->transport)($request);
+        $sentRequest = $this->client->getLastRequest();
+
+        self::assertSame($expectedResponse, $actualResponse);
+        self::assertSame($request->method(), $sentRequest->getMethod());
+        self::assertSame($request->uri(), $sentRequest->getUri()->__toString());
+        self::assertSame('', $sentRequest->getBody()->__toString());
+        self::assertSame(['application/json'], $sentRequest->getHeader('Content-Type'));
+        self::assertSame(['application/json'], $sentRequest->getHeader('Accept'));
+    }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes
| Fixed issues | 

#### Summary

Some services are not happy with e.g. an empty json body.

For example:

This succeeds

```
curl https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration -H'Content-Type: application/json'
```

This fails with message 'bad request':

```
curl https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration -d'[]' -H'Content-Type: application/json'
```


Therefor, I changed the `RequestInterface::body()` method  so that it can return an `array|null`
