### PR TITLE
Make transport templated

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ use Phpro\HttpTools\Transport\TransportInterface;
 class ListSomething
 {
     public function __construct(
+        /**
+         * TransportInterface<array, array>
+         */
         private TransportInterface $transport
     ) {}
 
@@ -170,6 +173,9 @@ use Phpro\HttpTools\Request\RequestInterface;
 // By wrapping the request in a Value Object, you can use named constructors to pass in filters and POST data.
 // You can add multiple named constructors if you want the list to behave in different ways in some cases.
 
+/**
+ * @implements RequestInterface<array>
+ */
 class ListRequest implements RequestInterface
 {
     public function method() : string
@@ -237,6 +243,9 @@ use function Amp\Promise\wait;
 class ListSomething
 {
     public function __construct(
+        /**
+         * AsyncTransportInterface<array, array>
+         */
         private AsyncTransportInterface $transport
     ) {}
 

--- a/src/Request/RequestInterface.php
+++ b/src/Request/RequestInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phpro\HttpTools\Request;
 
 /**
+ * @template BodyType
  * @psalm-immutable
  */
 interface RequestInterface
@@ -18,5 +19,8 @@ interface RequestInterface
 
     public function uriParameters(): array;
 
-    public function body(): ?array;
+    /**
+     * @return BodyType
+     */
+    public function body();
 }

--- a/src/Transport/AsyncTransportInterface.php
+++ b/src/Transport/AsyncTransportInterface.php
@@ -8,12 +8,15 @@ use Amp\Promise;
 use Phpro\HttpTools\Request\RequestInterface;
 
 /**
- * @template R
+ * @template RequestType
+ * @template ResponseType
  */
 interface AsyncTransportInterface
 {
     /**
-     * @return Promise<R>
+     * @param RequestInterface<RequestType> $request
+     *
+     * @return Promise<ResponseType>
      */
     public function __invoke(RequestInterface $request): Promise;
 }

--- a/src/Transport/AsyncTransportInterface.php
+++ b/src/Transport/AsyncTransportInterface.php
@@ -7,7 +7,13 @@ namespace Phpro\HttpTools\Transport;
 use Amp\Promise;
 use Phpro\HttpTools\Request\RequestInterface;
 
+/**
+ * @template R
+ */
 interface AsyncTransportInterface
 {
+    /**
+     * @return Promise<R>
+     */
     public function __invoke(RequestInterface $request): Promise;
 }

--- a/src/Transport/Json/AsyncJsonTransport.php
+++ b/src/Transport/Json/AsyncJsonTransport.php
@@ -19,7 +19,7 @@ use function Safe\json_decode;
 use function Safe\json_encode;
 
 /**
- * @implements AsyncTransportInterface<array>
+ * @implements AsyncTransportInterface<array|null, array>
  */
 final class AsyncJsonTransport implements AsyncTransportInterface
 {
@@ -53,6 +53,8 @@ final class AsyncJsonTransport implements AsyncTransportInterface
     }
 
     /**
+     * @param RequestInterface<array|null> $request
+     *
      * @throws \Psr\Http\Client\ClientExceptionInterface
      * @throws \Safe\Exceptions\JsonException
      *

--- a/src/Transport/Json/AsyncJsonTransport.php
+++ b/src/Transport/Json/AsyncJsonTransport.php
@@ -11,14 +11,17 @@ use Http\Client\HttpAsyncClient;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Phpro\HttpTools\Async\HttplugPromiseAdapter;
 use Phpro\HttpTools\Request\RequestInterface;
-use Phpro\HttpTools\Transport\TransportInterface;
+use Phpro\HttpTools\Transport\AsyncTransportInterface;
 use Phpro\HttpTools\Uri\UriBuilderInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use function Safe\json_decode;
 use function Safe\json_encode;
 
-final class AsyncJsonTransport implements TransportInterface
+/**
+ * @implements AsyncTransportInterface<array>
+ */
+final class AsyncJsonTransport implements AsyncTransportInterface
 {
     private HttpAsyncClient $client;
     private UriBuilderInterface $uriBuilder;

--- a/src/Transport/Json/JsonTransport.php
+++ b/src/Transport/Json/JsonTransport.php
@@ -15,7 +15,7 @@ use function Safe\json_decode;
 use function Safe\json_encode;
 
 /**
- * @implements TransportInterface<array>
+ * @implements TransportInterface<array|null, array>
  */
 final class JsonTransport implements TransportInterface
 {
@@ -49,6 +49,8 @@ final class JsonTransport implements TransportInterface
     }
 
     /**
+     * @param RequestInterface<array|null> $request
+     *
      * @throws \Psr\Http\Client\ClientExceptionInterface
      * @throws \Safe\Exceptions\JsonException
      */

--- a/src/Transport/Json/JsonTransport.php
+++ b/src/Transport/Json/JsonTransport.php
@@ -14,6 +14,9 @@ use Psr\Http\Message\StreamFactoryInterface;
 use function Safe\json_decode;
 use function Safe\json_encode;
 
+/**
+ * @implements TransportInterface<array>
+ */
 final class JsonTransport implements TransportInterface
 {
     private ClientInterface $client;

--- a/src/Transport/TransportInterface.php
+++ b/src/Transport/TransportInterface.php
@@ -6,10 +6,13 @@ namespace Phpro\HttpTools\Transport;
 
 use Phpro\HttpTools\Request\RequestInterface;
 
+/**
+ * @template R
+ */
 interface TransportInterface
 {
     /**
-     * @return mixed Feel free to use any return type you please!
+     * @return R
      */
     public function __invoke(RequestInterface $request);
 }

--- a/src/Transport/TransportInterface.php
+++ b/src/Transport/TransportInterface.php
@@ -7,12 +7,15 @@ namespace Phpro\HttpTools\Transport;
 use Phpro\HttpTools\Request\RequestInterface;
 
 /**
- * @template R
+ * @template RequestType
+ * @template ResponseType
  */
 interface TransportInterface
 {
     /**
-     * @return R
+     * @param RequestInterface<RequestType> $request
+     *
+     * @return ResponseType
      */
     public function __invoke(RequestInterface $request);
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

#### Summary

This PR adds the ability to type the return type of the `TransportInterface::__invoke()` method.