### PR TITLE
Add PSR7 Response decoder

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -36,6 +36,7 @@ This package contains some frequently used encoders / decoders for you:
 | `StreamDecoder` | `DecoderInterface<StreamInterface>` | Returns the PSR-7 Stream as response result |
 | `RawEncoder` | `EncoderInterface<string>` | Adds raw string as request body |
 | `RawDecoder` | `DecoderInterface<string>` | Returns the raw PSR-7 body string as response result |
+| `ResponseDecoder` | `DecoderInterface<ResponseInterface>` | Returns the received PSR-7 response as result |
 
 ## Built-in transport presets:
 
@@ -45,9 +46,9 @@ We've composed some of the encodings above into pre-configured transports:
 | Preset | RequestType | ResponseType |
 | --- | --- | --- |
 | `JsonPreset::sync()` | `?array` | `array` |
-| `JsonPreset::async()` | `?array` | `Promise<array>`> |
+| `JsonPreset::async()` | `?array` | `Promise<array>` |
 | `RawPreset::sync()` | `string` | `string` |
-| `RawPreset::async()` | `string` | `Promise<string>`> |
+| `RawPreset::async()` | `string` | `Promise<string>` |
 
 ## Creating your own configuration
 

--- a/src/Encoding/Psr7/ResponseDecoder.php
+++ b/src/Encoding/Psr7/ResponseDecoder.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Encoding\Psr7;
+
+use Phpro\HttpTools\Encoding\DecoderInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * @implements DecoderInterface<ResponseInterface>
+ */
+final class ResponseDecoder implements DecoderInterface
+{
+    public static function createWithAutodiscoveredPsrFactories(): self
+    {
+        return new self();
+    }
+
+    public function __invoke(ResponseInterface $response): ResponseInterface
+    {
+        return $response;
+    }
+}

--- a/tests/Unit/Encoding/Psr7/ResponseDecoderTest.php
+++ b/tests/Unit/Encoding/Psr7/ResponseDecoderTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Tests\Unit\Encoding\Psr7;
+
+use Phpro\HttpTools\Encoding\Psr7\ResponseDecoder;
+use Phpro\HttpTools\Test\UseHttpFactories;
+use PHPUnit\Framework\TestCase;
+
+final class ResponseDecoderTest extends TestCase
+{
+    use UseHttpFactories;
+
+    /** @test */
+    public function it_can_decode_response(): void
+    {
+        $decoder = ResponseDecoder::createWithAutodiscoveredPsrFactories();
+        $response = $this->createResponse();
+        $decoded = $decoder($response);
+
+        self::assertSame($response, $decoded);
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | 

#### Summary

Adds a decoder that can just return the PSR7 Response so that the end user can also access response headers and status code.
