### PR TITLE
Add SDK Tools

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -5,6 +5,7 @@ return PhpCsFixer\Config::create()
         \Symfony\Component\Finder\Finder::create()
             ->name('*.php')
             ->in([
+                __DIR__ . '/examples',
                 __DIR__ . '/src',
                 __DIR__ . '/tests',
             ])

--- a/README.md
+++ b/README.md
@@ -276,6 +276,15 @@ class ListSomething
 
 [More info ...](http://docs.php-http.org/en/latest/components/promise.html)
 
+
+## SDK
+
+In some situations, writing request handlers might be overkill.
+This package also provides some tools to compose a more generic API client instead.
+However, our primary suggestion is to create specific request handlers instead!
+
+[More information on creating SDKs](docs/sdk.md)
+
 ## Testing HTTP clients
 
 This tool provided some traits for unit testing your API client with PHPUnit.

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -1,0 +1,96 @@
+# Creating a Software Development kit for API's
+
+If your API is very straight forward, you might not want to create request handlers for every action.
+You could for example create a more classic API with this package as well.
+
+We provide some tools to compose straight-forward Rest HTTP resources.
+Here is an example for a REST service:
+
+```php
+use Phpro\HttpTools\Sdk\HttpResource;
+use Phpro\HttpTools\Sdk\Rest;
+use Phpro\HttpTools\Request\Request;
+
+/**
+ * @template ResultType
+ * @extends HttpResource<ResultType>
+ */
+final class UsersResouce extends HttpResource
+{
+    use Rest\CreateTrait;
+    use Rest\FindTrait;
+    use Rest\GetTrait;
+    use Rest\UpdateTrait;
+    use Rest\PatchTrait;
+    use Rest\DeleteTrait;
+
+    protected function path(): string
+    {
+        return '/users';
+    }
+    
+    public function me()
+    {
+        $request = new Request('GET', '/user', [], null);
+        return $this->transport()($request); 
+    }
+}
+```
+
+You could wrap multiple resources in an SDK client like this:
+
+```php
+
+use Phpro\HttpTools\Transport\TransportInterface;
+
+/**
+ * @template ResultType
+ */
+final class MyClient
+{
+    /**
+     * @var UsersResouce<ResultType>
+     * @psalm-readonly
+     */
+    public $users;
+
+    /**
+     * @param TransportInterface<array|null, ResultType> $transport
+     */
+    public function __construct(TransportInterface $transport)
+    {
+        $this->users = new UsersResouce($transport);
+    }
+}
+```
+
+Example usage:
+
+```php
+/** @var TransportInterface<array|null, UserModel> $transport */
+/** @var MyClient<array> $sdk */
+$sdk = new MyClient($transport);
+
+var_dump($sdk->users->find('veewee'));
+```
+
+You could even swap the transport with one that supports a different output type and still keep type-safety!
+
+> **Note**: If you are using the serializer transport, you might want to set the output types from within the Client.
+> You might also want to create a separate function for delete and find.
+
+
+# Built-in traits:
+
+These are some very opinionated traits that can be used to build your SDK.
+If you want to change something for your specific case, you can implement your own method or trait.
+
+| Trait | Description |
+| --- | --- |
+| CreateTrait<ResponseType> | Can be used to create a new resource from an array |
+| DeleteTrait<ResponseType> | Can be used to delete a resource from an identifier |
+| FindTrait<ResponseType> | Can be used to find a resource with an identifier |
+| GetTrait<ResponseType> | Can be used to list all resources |
+| PatchTrait<ResponseType> | Can be used to patch a resource with an identifier from an array |
+| UpdateTrait<ResponseType> | Can be used to update a resource with an identifier from an array |
+

--- a/examples/sdk.php
+++ b/examples/sdk.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+require dirname(__DIR__).'/vendor/autoload.php';
+
+use Http\Client\Common\Plugin\AuthenticationPlugin;
+use Http\Client\Common\Plugin\BaseUriPlugin;
+use Http\Message\Authentication\BasicAuth;
+use Nyholm\Psr7\Uri;
+use Phpro\HttpTools\Client\Factory\AutoDiscoveredClientFactory;
+use Phpro\HttpTools\Sdk\HttpResource;
+use Phpro\HttpTools\Sdk\Rest\CreateTrait;
+use Phpro\HttpTools\Sdk\Rest\DeleteTrait;
+use Phpro\HttpTools\Sdk\Rest\FindTrait;
+use Phpro\HttpTools\Sdk\Rest\GetTrait;
+use Phpro\HttpTools\Sdk\Rest\PatchTrait;
+use Phpro\HttpTools\Sdk\Rest\UpdateTrait;
+use Phpro\HttpTools\Transport\Presets\JsonPreset;
+use Phpro\HttpTools\Transport\TransportInterface;
+use Phpro\HttpTools\Uri\TemplatedUriBuilder;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer;
+
+$normalizers = [new ObjectNormalizer(), new ArrayDenormalizer()];
+$encoders = [new JsonEncoder()];
+$serializer = new Serializer($normalizers, $encoders);
+
+$client = AutoDiscoveredClientFactory::create([
+    new BaseUriPlugin(new Uri('https://api.github.com')),
+    new AuthenticationPlugin(
+        new BasicAuth('user', 'pass')
+    ),
+]);
+
+$transport = JsonPreset::sync($client, new TemplatedUriBuilder());
+
+/**
+ * @template ResultType
+ * @extends HttpResource<ResultType>
+ */
+final class UsersResouce extends HttpResource
+{
+    use CreateTrait;
+    use DeleteTrait;
+    use FindTrait;
+    use GetTrait;
+    use PatchTrait;
+    use UpdateTrait;
+
+    protected function path(): string
+    {
+        return '/users';
+    }
+}
+
+/**
+ * @template ResultType
+ */
+final class Sdk
+{
+    /**
+     * @var UsersResouce<ResultType>
+     * @psalm-readonly
+     */
+    public $users;
+
+    /**
+     * @param TransportInterface<array|null, ResultType> $transport
+     */
+    public function __construct(TransportInterface $transport)
+    {
+        $this->users = new UsersResouce($transport);
+    }
+}
+
+/** @var Sdk<array> $sdk */
+$sdk = new Sdk($transport);
+
+/** @psalm-suppress ForbiddenCode */
+var_dump($sdk->users->find('veewee'));

--- a/phive.xml
+++ b/phive.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="psalm" version="3.16" installed="3.16" location="./tools/psalm.phar" copy="true"/>
+  <phar name="psalm" version="4.3.1" installed="4.3.1" location="./tools/psalm.phar" copy="true"/>
   <phar name="phpunit" version="^9.3.9" installed="9.3.9" location="./tools/phpunit.phar" copy="true"/>
   <phar name="php-cs-fixer" version="^2.17.0" installed="2.17.1" location="./tools/php-cs-fixer.phar" copy="true"/>
 </phive>

--- a/psalm.xml
+++ b/psalm.xml
@@ -8,6 +8,7 @@
 >
     <projectFiles>
         <directory name="src" />
+        <directory name="examples" />
         <ignoreFiles>
             <directory name="vendor" />
         </ignoreFiles>

--- a/src/Encoding/Json/JsonDecoder.php
+++ b/src/Encoding/Json/JsonDecoder.php
@@ -20,6 +20,10 @@ final class JsonDecoder implements DecoderInterface
 
     public function __invoke(ResponseInterface $response): array
     {
-        return (array) json_decode((string) $response->getBody(), true);
+        if (!$responseBody = (string) $response->getBody()) {
+            return [];
+        }
+
+        return (array) json_decode($responseBody, true);
     }
 }

--- a/src/Formatter/RemoveSensitiveHeadersFormatter.php
+++ b/src/Formatter/RemoveSensitiveHeadersFormatter.php
@@ -44,7 +44,7 @@ final class RemoveSensitiveHeadersFormatter implements HttpFormatter
 
     private function removeCredentials(string $info): string
     {
-        return (string) array_reduce(
+        return array_reduce(
             $this->sensitiveHeaders,
             /** @psalm-suppress InvalidReturnStatement, InvalidReturnType */
             fn (string $sensitiveData, string $header): string => preg_replace(

--- a/src/Formatter/RemoveSensitiveJsonKeysFormatter.php
+++ b/src/Formatter/RemoveSensitiveJsonKeysFormatter.php
@@ -44,7 +44,7 @@ final class RemoveSensitiveJsonKeysFormatter implements HttpFormatter
 
     private function removeCredentials(string $info): string
     {
-        return (string) array_reduce(
+        return array_reduce(
             $this->sensitiveJsonKeys,
             /** @psalm-suppress InvalidReturnStatement, InvalidReturnType */
             fn (string $sensitiveData, string $jsonKey): string => preg_replace(

--- a/src/Sdk/HttpResource.php
+++ b/src/Sdk/HttpResource.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Sdk;
+
+use Phpro\HttpTools\Transport\TransportInterface;
+
+/**
+ * @template ResponseType
+ */
+abstract class HttpResource
+{
+    /**
+     * @var TransportInterface<array|null, ResponseType>
+     */
+    private TransportInterface $transport;
+
+    /**
+     * @param TransportInterface<array|null, ResponseType> $transport
+     */
+    public function __construct(TransportInterface $transport)
+    {
+        $this->transport = $transport;
+    }
+
+    abstract protected function path(): string;
+
+    /**
+     * @return TransportInterface<array|null, ResponseType>
+     */
+    protected function transport(): TransportInterface
+    {
+        return $this->transport;
+    }
+}

--- a/src/Sdk/Rest/CreateTrait.php
+++ b/src/Sdk/Rest/CreateTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Sdk\Rest;
+
+use Phpro\HttpTools\Request\Request;
+use Phpro\HttpTools\Request\RequestInterface;
+use Phpro\HttpTools\Transport\TransportInterface;
+
+/**
+ * @template ResponseType
+ */
+trait CreateTrait
+{
+    abstract protected function transport(): TransportInterface;
+
+    abstract protected function path(): string;
+
+    /**
+     * @return ResponseType
+     */
+    public function create(array $data)
+    {
+        /** @var RequestInterface<array|null> $request */
+        $request = new Request('POST', $this->path(), [], $data);
+
+        return $this->transport()($request);
+    }
+}

--- a/src/Sdk/Rest/DeleteTrait.php
+++ b/src/Sdk/Rest/DeleteTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Sdk\Rest;
+
+use Phpro\HttpTools\Request\Request;
+use Phpro\HttpTools\Request\RequestInterface;
+use Phpro\HttpTools\Transport\TransportInterface;
+
+/**
+ * @template ResponseType
+ */
+trait DeleteTrait
+{
+    abstract protected function transport(): TransportInterface;
+
+    abstract protected function path(): string;
+
+    /**
+     * @return ResponseType
+     */
+    public function delete(string $identifier)
+    {
+        /** @var RequestInterface<array|null> $request */
+        $request = new Request('DELETE', $this->path().'/'.$identifier, [], null);
+
+        return $this->transport()($request);
+    }
+}

--- a/src/Sdk/Rest/FindTrait.php
+++ b/src/Sdk/Rest/FindTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Sdk\Rest;
+
+use Phpro\HttpTools\Request\Request;
+use Phpro\HttpTools\Request\RequestInterface;
+use Phpro\HttpTools\Transport\TransportInterface;
+
+/**
+ * @template ResponseType
+ */
+trait FindTrait
+{
+    abstract protected function transport(): TransportInterface;
+
+    abstract protected function path(): string;
+
+    /**
+     * @return ResponseType
+     */
+    public function find(string $identifier)
+    {
+        /** @var RequestInterface<array|null> $request */
+        $request = new Request('GET', $this->path().'/'.$identifier, [], null);
+
+        return $this->transport()($request);
+    }
+}

--- a/src/Sdk/Rest/GetTrait.php
+++ b/src/Sdk/Rest/GetTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Sdk\Rest;
+
+use Phpro\HttpTools\Request\Request;
+use Phpro\HttpTools\Request\RequestInterface;
+use Phpro\HttpTools\Transport\TransportInterface;
+
+/**
+ * @template ResponseType
+ */
+trait GetTrait
+{
+    abstract protected function transport(): TransportInterface;
+
+    abstract protected function path(): string;
+
+    /**
+     * @return ResponseType
+     */
+    public function get()
+    {
+        /** @var RequestInterface<array|null> $request */
+        $request = new Request('GET', $this->path(), [], null);
+
+        return $this->transport()($request);
+    }
+}

--- a/src/Sdk/Rest/PatchTrait.php
+++ b/src/Sdk/Rest/PatchTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Sdk\Rest;
+
+use Phpro\HttpTools\Request\Request;
+use Phpro\HttpTools\Request\RequestInterface;
+use Phpro\HttpTools\Transport\TransportInterface;
+
+/**
+ * @template ResponseType
+ */
+trait PatchTrait
+{
+    abstract protected function transport(): TransportInterface;
+
+    abstract protected function path(): string;
+
+    /**
+     * @return ResponseType
+     */
+    public function patch(string $identifier, array $data)
+    {
+        /** @var RequestInterface<array|null> $request */
+        $request = new Request('PATCH', $this->path().'/'.$identifier, [], $data);
+
+        return $this->transport()($request);
+    }
+}

--- a/src/Sdk/Rest/UpdateTrait.php
+++ b/src/Sdk/Rest/UpdateTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Sdk\Rest;
+
+use Phpro\HttpTools\Request\Request;
+use Phpro\HttpTools\Request\RequestInterface;
+use Phpro\HttpTools\Transport\TransportInterface;
+
+/**
+ * @template ResponseType
+ */
+trait UpdateTrait
+{
+    abstract protected function transport(): TransportInterface;
+
+    abstract protected function path(): string;
+
+    /**
+     * @return ResponseType
+     */
+    public function update(string $identifier, array $data)
+    {
+        /** @var RequestInterface<array|null> $request */
+        $request = new Request('PUT', $this->path().'/'.$identifier, [], $data);
+
+        return $this->transport()($request);
+    }
+}

--- a/tests/Unit/Encoding/Json/JsonDecoderTest.php
+++ b/tests/Unit/Encoding/Json/JsonDecoderTest.php
@@ -22,4 +22,14 @@ final class JsonDecoderTest extends TestCase
 
         self::assertSame(['hello' => 'world'], $decoded);
     }
+
+    /** @test */
+    public function it_can_decode_empty_body_to_empty_array(): void
+    {
+        $decoder = JsonDecoder::createWithAutodiscoveredPsrFactories();
+        $response = $this->createResponse()->withBody($this->createStream(''));
+        $decoded = $decoder($response);
+
+        self::assertSame([], $decoded);
+    }
 }

--- a/tests/Unit/Sdk/Rest/CreateTest.php
+++ b/tests/Unit/Sdk/Rest/CreateTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Tests\Unit\Sdk\Rest;
+
+use Http\Message\RequestMatcher\CallbackRequestMatcher;
+use Http\Mock\Client;
+use Phpro\HttpTools\Sdk\HttpResource;
+use Phpro\HttpTools\Sdk\Rest\CreateTrait;
+use Phpro\HttpTools\Test\UseMockClient;
+use Phpro\HttpTools\Transport\Presets\JsonPreset;
+use Phpro\HttpTools\Uri\RawUriBuilder;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use function Safe\json_encode;
+
+final class CreateTest extends TestCase
+{
+    use UseMockClient;
+
+    private Client $client;
+    private HttpResource $resource;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->mockClient();
+        $transport = JsonPreset::sync($this->client, RawUriBuilder::createWithAutodiscoveredPsrFactories());
+        $this->resource = new class($transport) extends HttpResource {
+            use CreateTrait;
+
+            protected function path(): string
+            {
+                return '/users';
+            }
+        };
+    }
+
+    /** @test */
+    public function it_can_create_a_resource(): void
+    {
+        $requestData = ['user' => 'aa'];
+        $responseData = ['id' => 1];
+
+        $this->client->on(
+            new CallbackRequestMatcher(
+                static fn (RequestInterface $request) => 'POST' === $request->getMethod()
+                        && '/users' === (string) $request->getUri()
+                        && (string) $request->getBody() === json_encode($requestData)
+            ),
+            $this->createResponse()
+                ->withBody(
+                     $this->createStream(json_encode($responseData))
+                 )
+        );
+
+        $actual = $this->resource->create($requestData);
+
+        self::assertSame($responseData, $actual);
+    }
+}

--- a/tests/Unit/Sdk/Rest/DeleteTest.php
+++ b/tests/Unit/Sdk/Rest/DeleteTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Tests\Unit\Sdk\Rest;
+
+use Http\Message\RequestMatcher\CallbackRequestMatcher;
+use Http\Mock\Client;
+use Phpro\HttpTools\Sdk\HttpResource;
+use Phpro\HttpTools\Sdk\Rest\DeleteTrait;
+use Phpro\HttpTools\Test\UseMockClient;
+use Phpro\HttpTools\Transport\Presets\JsonPreset;
+use Phpro\HttpTools\Uri\RawUriBuilder;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+
+final class DeleteTest extends TestCase
+{
+    use UseMockClient;
+
+    private Client $client;
+    private HttpResource $resource;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->mockClient();
+        $transport = JsonPreset::sync($this->client, RawUriBuilder::createWithAutodiscoveredPsrFactories());
+        $this->resource = new class($transport) extends HttpResource {
+            use DeleteTrait;
+
+            protected function path(): string
+            {
+                return '/users';
+            }
+        };
+    }
+
+    /** @test */
+    public function it_can_delete_a_resource(): void
+    {
+        $responseData = [];
+
+        $this->client->on(
+            new CallbackRequestMatcher(
+                static fn (RequestInterface $request) => 'DELETE' === $request->getMethod()
+                        && '/users/1' === (string) $request->getUri()
+                        && '' === (string) $request->getBody()
+            ),
+            $this->createResponse()
+                ->withBody(
+                     $this->createStream('')
+                 )
+        );
+
+        $actual = $this->resource->delete('1');
+
+        self::assertSame($responseData, $actual);
+    }
+}

--- a/tests/Unit/Sdk/Rest/FindTest.php
+++ b/tests/Unit/Sdk/Rest/FindTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Tests\Unit\Sdk\Rest;
+
+use Http\Message\RequestMatcher\CallbackRequestMatcher;
+use Http\Mock\Client;
+use Phpro\HttpTools\Sdk\HttpResource;
+use Phpro\HttpTools\Sdk\Rest\FindTrait;
+use Phpro\HttpTools\Test\UseMockClient;
+use Phpro\HttpTools\Transport\Presets\JsonPreset;
+use Phpro\HttpTools\Uri\RawUriBuilder;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use function Safe\json_encode;
+
+final class FindTest extends TestCase
+{
+    use UseMockClient;
+
+    private Client $client;
+    private HttpResource $resource;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->mockClient();
+        $transport = JsonPreset::sync($this->client, RawUriBuilder::createWithAutodiscoveredPsrFactories());
+        $this->resource = new class($transport) extends HttpResource {
+            use FindTrait;
+
+            protected function path(): string
+            {
+                return '/users';
+            }
+        };
+    }
+
+    /** @test */
+    public function it_can_find_a_resource(): void
+    {
+        $responseData = ['id' => 1];
+
+        $this->client->on(
+            new CallbackRequestMatcher(
+                static fn (RequestInterface $request) => 'GET' === $request->getMethod()
+                        && '/users/1' === (string) $request->getUri()
+                        && '' === (string) $request->getBody()
+            ),
+            $this->createResponse()
+                ->withBody(
+                     $this->createStream(json_encode($responseData))
+                 )
+        );
+
+        $actual = $this->resource->find('1');
+
+        self::assertSame($responseData, $actual);
+    }
+}

--- a/tests/Unit/Sdk/Rest/GetTest.php
+++ b/tests/Unit/Sdk/Rest/GetTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Tests\Unit\Sdk\Rest;
+
+use Http\Message\RequestMatcher\CallbackRequestMatcher;
+use Http\Mock\Client;
+use Phpro\HttpTools\Sdk\HttpResource;
+use Phpro\HttpTools\Sdk\Rest\GetTrait;
+use Phpro\HttpTools\Test\UseMockClient;
+use Phpro\HttpTools\Transport\Presets\JsonPreset;
+use Phpro\HttpTools\Uri\RawUriBuilder;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use function Safe\json_encode;
+
+final class GetTest extends TestCase
+{
+    use UseMockClient;
+
+    private Client $client;
+    private HttpResource $resource;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->mockClient();
+        $transport = JsonPreset::sync($this->client, RawUriBuilder::createWithAutodiscoveredPsrFactories());
+        $this->resource = new class($transport) extends HttpResource {
+            use GetTrait;
+
+            protected function path(): string
+            {
+                return '/users';
+            }
+        };
+    }
+
+    /** @test */
+    public function it_can_get_a_resource(): void
+    {
+        $responseData = [['id' => 1], ['id' => 2]];
+
+        $this->client->on(
+            new CallbackRequestMatcher(
+                static fn (RequestInterface $request) => 'GET' === $request->getMethod()
+                        && '/users' === (string) $request->getUri()
+                        && '' === (string) $request->getBody()
+            ),
+            $this->createResponse()
+                ->withBody(
+                     $this->createStream(json_encode($responseData))
+                 )
+        );
+
+        $actual = $this->resource->get();
+
+        self::assertSame($responseData, $actual);
+    }
+}

--- a/tests/Unit/Sdk/Rest/PatchTest.php
+++ b/tests/Unit/Sdk/Rest/PatchTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Tests\Unit\Sdk\Rest;
+
+use Http\Message\RequestMatcher\CallbackRequestMatcher;
+use Http\Mock\Client;
+use Phpro\HttpTools\Sdk\HttpResource;
+use Phpro\HttpTools\Sdk\Rest\PatchTrait;
+use Phpro\HttpTools\Test\UseMockClient;
+use Phpro\HttpTools\Transport\Presets\JsonPreset;
+use Phpro\HttpTools\Uri\RawUriBuilder;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use function Safe\json_encode;
+
+final class PatchTest extends TestCase
+{
+    use UseMockClient;
+
+    private Client $client;
+    private HttpResource $resource;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->mockClient();
+        $transport = JsonPreset::sync($this->client, RawUriBuilder::createWithAutodiscoveredPsrFactories());
+        $this->resource = new class($transport) extends HttpResource {
+            use PatchTrait;
+
+            protected function path(): string
+            {
+                return '/users';
+            }
+        };
+    }
+
+    /** @test */
+    public function it_can_patch_a_resource(): void
+    {
+        $requestData = ['user' => 'a'];
+        $responseData = ['id' => 1];
+
+        $this->client->on(
+            new CallbackRequestMatcher(
+                static fn (RequestInterface $request) => 'PATCH' === $request->getMethod()
+                        && '/users/1' === (string) $request->getUri()
+                        && (string) $request->getBody() === json_encode($requestData)
+            ),
+            $this->createResponse()
+                ->withBody(
+                     $this->createStream(json_encode($responseData))
+                 )
+        );
+
+        $actual = $this->resource->patch('1', $requestData);
+
+        self::assertSame($responseData, $actual);
+    }
+}

--- a/tests/Unit/Sdk/Rest/UpdateTest.php
+++ b/tests/Unit/Sdk/Rest/UpdateTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Tests\Unit\Sdk\Rest;
+
+use Http\Message\RequestMatcher\CallbackRequestMatcher;
+use Http\Mock\Client;
+use Phpro\HttpTools\Sdk\HttpResource;
+use Phpro\HttpTools\Sdk\Rest\UpdateTrait;
+use Phpro\HttpTools\Test\UseMockClient;
+use Phpro\HttpTools\Transport\Presets\JsonPreset;
+use Phpro\HttpTools\Uri\RawUriBuilder;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use function Safe\json_encode;
+
+final class UpdateTest extends TestCase
+{
+    use UseMockClient;
+
+    private Client $client;
+    private HttpResource $resource;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->mockClient();
+        $transport = JsonPreset::sync($this->client, RawUriBuilder::createWithAutodiscoveredPsrFactories());
+        $this->resource = new class($transport) extends HttpResource {
+            use UpdateTrait;
+
+            protected function path(): string
+            {
+                return '/users';
+            }
+        };
+    }
+
+    /** @test */
+    public function it_can_patch_a_resource(): void
+    {
+        $requestData = ['user' => 'a'];
+        $responseData = ['id' => 1];
+
+        $this->client->on(
+            new CallbackRequestMatcher(
+                static fn (RequestInterface $request) => 'PUT' === $request->getMethod()
+                        && '/users/1' === (string) $request->getUri()
+                        && (string) $request->getBody() === json_encode($requestData)
+            ),
+            $this->createResponse()
+                ->withBody(
+                     $this->createStream(json_encode($responseData))
+                 )
+        );
+
+        $actual = $this->resource->update('1', $requestData);
+
+        self::assertSame($responseData, $actual);
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | yes
| Fixed issues | 

#### Summary

This PR  adds some oppinionated tools to create basic REST API clients (SDKs).

Example:

```php
final class UsersResouce extends HttpResource
{
    use Rest\CreateTrait;
    use Rest\FindTrait;
    use Rest\GetTrait;
    use Rest\UpdateTrait;
    use Rest\PatchTrait;
    use Rest\DeleteTrait;

    protected function path(): string
    {
        return '/users';
    }
    
    public function me()
    {
        $request = new Request('GET', '/user', [], null);
        return $this->transport()($request); 
    }
}
```

```php
/**
 * @template ResultType
 */
final class MyClient
{
    /**
     * @var UsersResouce<ResultType>
     * @psalm-readonly
     */
    public $users;

    /**
     * @param TransportInterface<array|null, ResultType> $transport
     */
    public function __construct(TransportInterface $transport)
    {
        $this->users = new UsersResouce($transport);
    }
}
```

```php
$sdk = new MyClient($transport);

var_dump($sdk->users->find('veewee'));
```

You can insert whatever transport you like. This way it can return: json, string, psr response, ....
However, if you use the serializer transport, you need to set the types inside your client.
