### PR TITLE
Make it possible to pass query params to HttpResource::get()

### DIFF
--- a/src/Sdk/Rest/GetTrait.php
+++ b/src/Sdk/Rest/GetTrait.php
@@ -20,10 +20,10 @@ trait GetTrait
     /**
      * @return ResponseType
      */
-    public function get()
+    public function get(array $uriParameters = [])
     {
         /** @var RequestInterface<array|null> $request */
-        $request = new Request('GET', $this->path(), [], null);
+        $request = new Request('GET', $this->path(), $uriParameters, null);
 
         return $this->transport()($request);
     }

--- a/src/Uri/RawUriBuilder.php
+++ b/src/Uri/RawUriBuilder.php
@@ -25,6 +25,12 @@ final class RawUriBuilder implements UriBuilderInterface
 
     public function __invoke(RequestInterface $request): UriInterface
     {
-        return $this->uriFactory->createUri($request->uri());
+        $uri = $this->uriFactory->createUri($request->uri());
+
+        if (!$request->uriParameters()) {
+            return $uri;
+        }
+
+        return $uri->withQuery(http_build_query($request->uriParameters()));
     }
 }

--- a/tests/Unit/Sdk/Rest/GetTest.php
+++ b/tests/Unit/Sdk/Rest/GetTest.php
@@ -44,8 +44,8 @@ final class GetTest extends TestCase
         $this->client->on(
             new CallbackRequestMatcher(
                 static fn (RequestInterface $request) => 'GET' === $request->getMethod()
-                        && '/users' === (string) $request->getUri()
-                        && '' === (string) $request->getBody()
+                    && '/users' === (string) $request->getUri()
+                    && '' === (string) $request->getBody()
             ),
             $this->createResponse()
                 ->withBody(
@@ -54,6 +54,28 @@ final class GetTest extends TestCase
         );
 
         $actual = $this->resource->get();
+
+        self::assertSame($responseData, $actual);
+    }
+
+    /** @test */
+    public function it_can_get_a_resource_with_query_params(): void
+    {
+        $responseData = [['id' => 1], ['id' => 2]];
+
+        $this->client->on(
+            new CallbackRequestMatcher(
+                static fn (RequestInterface $request) => 'GET' === $request->getMethod()
+                     && '/users?param1=value1' === (string) $request->getUri()
+                     && '' === (string) $request->getBody()
+            ),
+            $this->createResponse()
+                ->withBody(
+                     $this->createStream(json_encode($responseData))
+                 )
+        );
+
+        $actual = $this->resource->get(['param1' => 'value1']);
 
         self::assertSame($responseData, $actual);
     }

--- a/tests/Unit/Uri/RawUriBuilderTest.php
+++ b/tests/Unit/Uri/RawUriBuilderTest.php
@@ -29,4 +29,14 @@ final class RawUriBuilderTest extends TestCase
         self::assertInstanceOf(UriInterface::class, $uri);
         self::assertSame($request->uri(), $uri->__toString());
     }
+
+    /** @test */
+    public function it_can_build_a_raw_uri_with_query_params(): void
+    {
+        $request = $this->createToolsRequest('GET', '/hello/world', ['param1' => 'value1']);
+        $uri = ($this->uriBuilder)($request);
+
+        self::assertInstanceOf(UriInterface::class, $uri);
+        self::assertSame('/hello/world?param1=value1', $uri->__toString());
+    }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues |

#### Summary

This PR makes it possible to pass query params to the `HttpResource::get()` methods.

```php
var_dump($sdk->users->get(['active' => 1, 'page' => 20]));
```
