### PR TITLE
Add callback plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ $middlewares = [
 **Built-in plugins**:
 
 - `AcceptLanguagePlugin`: Makes it possible to add an Accept-Language to a request.
+- `CallbackPlugin`: Makes it possible to promote a simple `callable` into a real `Plugin`.
 
 **Remember**: [There are a shitload of HTTPlug middleware available already.](http://docs.php-http.org/en/latest/plugins/) Try on of them before writing your own one!
 

--- a/src/Plugin/CallbackPlugin.php
+++ b/src/Plugin/CallbackPlugin.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Plugin;
+
+use Http\Client\Common\Plugin;
+use Http\Promise\Promise;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * @psalm-type Step = callable(RequestInterface): Promise
+ * @psalm-type PluginCallback = callable(RequestInterface, Step, Step): Promise
+ */
+final class CallbackPlugin implements Plugin
+{
+    /**
+     * @var PluginCallback
+     */
+    private $callback;
+
+    /**
+     * @param PluginCallback $callback
+     */
+    public function __construct(callable $callback)
+    {
+        $this->callback = $callback;
+    }
+
+    /**
+     * @param Step $next
+     * @param Step $first
+     */
+    public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
+    {
+        return ($this->callback)($request, $next, $first);
+    }
+}

--- a/tests/Unit/Plugin/CallbackPluginTest.php
+++ b/tests/Unit/Plugin/CallbackPluginTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Tests\Unit\Plugin;
+
+use Http\Mock\Client;
+use Http\Promise\Promise;
+use Phpro\HttpTools\Client\Configurator\PluginsConfigurator;
+use Phpro\HttpTools\Plugin\CallbackPlugin;
+use Phpro\HttpTools\Test\UseMockClient;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+
+final class CallbackPluginTest extends TestCase
+{
+    use UseMockClient;
+
+    private Client $mockClient;
+    private ClientInterface $client;
+
+    protected function setUp(): void
+    {
+        $this->client = PluginsConfigurator::configure(
+            $this->mockClient = $this->mockClient(function (Client $client): Client {
+                $client->setDefaultResponse($this->createResponse(204));
+
+                return $client;
+            }),
+            [
+                new CallbackPlugin(
+                    static function (RequestInterface $request, callable $next, callable $first): Promise {
+                        return $next($request->withAddedHeader('Hello', 'World'));
+                    }
+                ),
+            ]
+        );
+    }
+
+    /** @test */
+    public function it_can_run_a_callback_as_plugin(): void
+    {
+        $response = $this->client->sendRequest($this->createRequest('GET', '/something'));
+        $lastRequest = $this->mockClient->getLastRequest();
+
+        self::assertSame('World', $lastRequest->getHeaderLine('Hello'));
+        self::assertSame(204, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | 

#### Summary

This change adds the possibility to promote a simple callable to a real Plugin.
Can be usefull in test scenarios.

Example of scenario that requires you to bust cached VCR requests.
(For example if you are testing a flow : fetch, update, refetch)

```php
return new CallbackPlugin(
      function (RequestInterface $request): RequestInterface {
          if ($this->singleRequestCacheBuster) {
              $request = $request->withAddedHeader('X-cache-buster', $this->singleRequestCacheBuster);
              $this->singleRequestCacheBuster = '';
          }

          return $next($request);
      };
);
```