### PR TITLE
Janvernieuwe serializer improvements

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -9,9 +9,10 @@
     <projectFiles>
         <directory name="src" />
         <directory name="examples" />
+        <directory name="static-analysis" />
         <ignoreFiles>
-            <directory name="vendor" />
             <directory name="tests" />
+            <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
     <stubs>

--- a/src/Transport/Serializer/SerializerTransport.php
+++ b/src/Transport/Serializer/SerializerTransport.php
@@ -6,7 +6,6 @@ namespace Phpro\HttpTools\Transport\Serializer;
 
 use Phpro\HttpTools\Request\Request;
 use Phpro\HttpTools\Request\RequestInterface;
-use Phpro\HttpTools\Serializer\SerializerException;
 use Phpro\HttpTools\Serializer\SerializerInterface;
 use Phpro\HttpTools\Transport\TransportInterface;
 
@@ -57,20 +56,19 @@ final class SerializerTransport implements TransportInterface
 
     public function __invoke(RequestInterface $request)
     {
-        if (!$this->outputType) {
-            throw SerializerException::noDeserializeTypeSpecified();
+        $response = ($this->transport)(
+            new Request(
+                $request->method(),
+                $request->uri(),
+                $request->uriParameters(),
+                null === $request->body() ? '' : $this->serializer->serialize($request->body())
+            )
+        );
+
+        if (null === $this->outputType) {
+            return;
         }
 
-        return $this->serializer->deserialize(
-            ($this->transport)(
-                new Request(
-                    $request->method(),
-                    $request->uri(),
-                    $request->uriParameters(),
-                    $this->serializer->serialize($request->body())
-                )
-            ),
-            $this->outputType
-        );
+        return $this->serializer->deserialize($response, $this->outputType);
     }
 }

--- a/static-analysis/Transport/Serializer/serializer-transport.php
+++ b/static-analysis/Transport/Serializer/serializer-transport.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\StaticAnalysis\Transport\Serializer;
+
+use Phpro\HttpTools\Request\Request;
+use Phpro\HttpTools\Serializer\SerializerInterface;
+use Phpro\HttpTools\Transport\Serializer\SerializerTransport;
+use Phpro\HttpTools\Transport\TransportInterface;
+
+final class Foo
+{
+}
+
+/**
+ * @param SerializerTransport<Foo, null> $x
+ *
+ * @return null
+ */
+function testEmptySerializer(SerializerTransport $x)
+{
+    return $x(new Request('GET', '/', [], new Foo()));
+}
+
+/**
+ * @param SerializerTransport<Foo, Foo> $x
+ */
+function testTargetSerializer(SerializerTransport $x): Foo
+{
+    return $x(new Request('GET', '/', [], new Foo()));
+}
+
+/**
+ * @param TransportInterface<string, string> $transport
+ */
+function test(SerializerInterface $serializer, TransportInterface $transport): void
+{
+    /** @var SerializerTransport<Foo, null> $serializerTransport */
+    $serializerTransport = new SerializerTransport($serializer, $transport);
+
+    testEmptySerializer($serializerTransport);
+
+    testTargetSerializer($serializerTransport->withOutputType(Foo::class));
+}

--- a/tests/Unit/Transport/Serializer/SerializerTransportTest.php
+++ b/tests/Unit/Transport/Serializer/SerializerTransportTest.php
@@ -70,7 +70,7 @@ final class SerializerTransportTest extends TestCase
     public function it_can_handle_requests_without_request_object(): void
     {
         $valueObject = new SomeValueObject('Hello', 'World');
-        $jsonData = \Safe\json_encode($data = ['x' => 'Hello', 'y' => 'World']);
+        $jsonData = Json\encode($data = ['x' => 'Hello', 'y' => 'World']);
         $request = $this->createToolsRequest('GET', '/', []);
 
         $this->client->on(
@@ -90,7 +90,7 @@ final class SerializerTransportTest extends TestCase
     public function it_can_handle_requests_without_response_type(): void
     {
         $valueObject = new SomeValueObject('Hello', 'World');
-        $jsonData = \Safe\json_encode($data = ['x' => 'Hello', 'y' => 'World']);
+        $jsonData = Json\encode($data = ['x' => 'Hello', 'y' => 'World']);
         $request = $this->createToolsRequest('GET', '/', [], $valueObject);
 
         $this->client->on(

--- a/tests/Unit/Transport/Serializer/SerializerTransportTest.php
+++ b/tests/Unit/Transport/Serializer/SerializerTransportTest.php
@@ -66,27 +66,27 @@ final class SerializerTransportTest extends TestCase
         self::assertEquals($valueObject, $result);
     }
 
-    /** @test */
-    public function it_can_not_serialize_requests_if_the_output_value_is_not_known(): void
-    {
-        $valueObject = new SomeValueObject('Hello', 'World');
-        $request = $this->createToolsRequest('GET', '/', [], $valueObject);
-
-        $this->expectException(SerializerException::class);
-        $this->expectExceptionMessage(SerializerException::noDeserializeTypeSpecified()->getMessage());
-        ($this->transport)($request);
-    }
+//    /** @test */
+//    public function it_can_not_serialize_requests_if_the_output_value_is_not_known(): void
+//    {
+//        $valueObject = new SomeValueObject('Hello', 'World');
+//        $request = $this->createToolsRequest('GET', '/', [], $valueObject);
+//
+//        $this->expectException(SerializerException::class);
+//        $this->expectExceptionMessage(SerializerException::noDeserializeTypeSpecified()->getMessage());
+//        ($this->transport)($request);
+//    }
 
     /** @test */
     public function it_can_handle_requests_without_request_object(): void
     {
         $valueObject = new SomeValueObject('Hello', 'World');
         $jsonData = \Safe\json_encode($data = ['x' => 'Hello', 'y' => 'World']);
-        $request = $this->createToolsRequest('GET', '/', [], null);
+        $request = $this->createToolsRequest('GET', '/', []);
 
         $this->client->on(
             new CallbackRequestMatcher(
-                fn (RequestInterface $httpRequest): bool => (string) $httpRequest->getBody() === $jsonData
+                fn (RequestInterface $httpRequest): bool => '' === (string) $httpRequest->getBody()
             ),
             $this->createResponse()->withBody($this->createStream($jsonData))
         );
@@ -114,6 +114,6 @@ final class SerializerTransportTest extends TestCase
         $transport = $this->transport;
         $result = $transport($request);
 
-        self::assertEquals($valueObject, $result);
+        self::assertEquals(null, $result);
     }
 }

--- a/tests/Unit/Transport/Serializer/SerializerTransportTest.php
+++ b/tests/Unit/Transport/Serializer/SerializerTransportTest.php
@@ -76,4 +76,44 @@ final class SerializerTransportTest extends TestCase
         $this->expectExceptionMessage(SerializerException::noDeserializeTypeSpecified()->getMessage());
         ($this->transport)($request);
     }
+
+    /** @test */
+    public function it_can_handle_requests_without_request_object(): void
+    {
+        $valueObject = new SomeValueObject('Hello', 'World');
+        $jsonData = \Safe\json_encode($data = ['x' => 'Hello', 'y' => 'World']);
+        $request = $this->createToolsRequest('GET', '/', [], null);
+
+        $this->client->on(
+            new CallbackRequestMatcher(
+                fn (RequestInterface $httpRequest): bool => (string) $httpRequest->getBody() === $jsonData
+            ),
+            $this->createResponse()->withBody($this->createStream($jsonData))
+        );
+
+        $transport = $this->transport->withOutputType(SomeValueObject::class);
+        $result = $transport($request);
+
+        self::assertEquals($valueObject, $result);
+    }
+
+    /** @test */
+    public function it_can_handle_requests_without_response_type(): void
+    {
+        $valueObject = new SomeValueObject('Hello', 'World');
+        $jsonData = \Safe\json_encode($data = ['x' => 'Hello', 'y' => 'World']);
+        $request = $this->createToolsRequest('GET', '/', [], $valueObject);
+
+        $this->client->on(
+            new CallbackRequestMatcher(
+                fn (RequestInterface $httpRequest): bool => (string) $httpRequest->getBody() === $jsonData
+            ),
+            $this->createResponse()->withBody($this->createStream($jsonData))
+        );
+
+        $transport = $this->transport;
+        $result = $transport($request);
+
+        self::assertEquals($valueObject, $result);
+    }
 }

--- a/tests/Unit/Transport/Serializer/SerializerTransportTest.php
+++ b/tests/Unit/Transport/Serializer/SerializerTransportTest.php
@@ -6,7 +6,6 @@ namespace Phpro\HttpTools\Tests\Unit\Transport\Serializer;
 
 use Http\Message\RequestMatcher\CallbackRequestMatcher;
 use Http\Mock\Client;
-use Phpro\HttpTools\Serializer\SerializerException;
 use Phpro\HttpTools\Serializer\SymfonySerializer;
 use Phpro\HttpTools\Test\UseHttpToolsFactories;
 use Phpro\HttpTools\Test\UseMockClient;
@@ -65,17 +64,6 @@ final class SerializerTransportTest extends TestCase
 
         self::assertEquals($valueObject, $result);
     }
-
-//    /** @test */
-//    public function it_can_not_serialize_requests_if_the_output_value_is_not_known(): void
-//    {
-//        $valueObject = new SomeValueObject('Hello', 'World');
-//        $request = $this->createToolsRequest('GET', '/', [], $valueObject);
-//
-//        $this->expectException(SerializerException::class);
-//        $this->expectExceptionMessage(SerializerException::noDeserializeTypeSpecified()->getMessage());
-//        ($this->transport)($request);
-//    }
 
     /** @test */
     public function it_can_handle_requests_without_request_object(): void


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no (maybe a tiny one)

#### Summary

Sometimes you don't need to serialize something on the request (GET).
And sometimes you don't need to deserialize a response (202, 204 responses)

This makes it so that if there is no request object or output type, the serialization is skipped.