### PR TITLE
VCR register replay before record plugin

### DIFF
--- a/src/Test/UseVcrClient.php
+++ b/src/Test/UseVcrClient.php
@@ -27,8 +27,8 @@ trait UseVcrClient
         $namingStrategy ??= new PathNamingStrategy();
 
         return [
-            new RecordPlugin($namingStrategy, $recorder),
             new ReplayPlugin($namingStrategy, $recorder, false),
+            new RecordPlugin($namingStrategy, $recorder),
         ];
     }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | n/a

#### Summary

Issue:  First replay of a recorded response with VCR fails.

Resolution: 
When using HTTP VCR, it requires the `ReplayPlugin`to be registered before `RecordPlugin`.
info https://docs.php-http.org/en/latest/plugins/vcr.html?highlight=VCR#example


