### PR TITLE
[WIP] Introduce fetch API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,9 @@
         }
     },
     "autoload": {
+        "files": [
+            "src/functions.php"
+        ],
         "psr-4": {
             "Phpro\\HttpTools\\": "src"
         }

--- a/src/Client/FetchClient.php
+++ b/src/Client/FetchClient.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Client;
+
+use Http\Client\Common\Plugin\ErrorPlugin;
+use Http\Client\Common\Plugin\HeaderSetPlugin;
+use Http\Client\Common\PluginClient;
+use Phpro\HttpTools\Request\Request;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\ResponseInterface;
+use Webmozart\Assert\Assert;
+
+/**
+ * This class is inspired on the JS fetch() function:.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch
+ *
+ * It also contains aliases, just like axios does:
+ * @see https://axios-http.com/docs/api_intro
+ *
+ * fetch(url[, config])
+ * get(url[, config])
+ * delete(url[, config])
+ * head(url[, config])
+ * options(url[, config])
+ * post(url[, data[, config]])
+ * put(url[, data[, config]])
+ * patch(url[, data[, config]])
+ *
+ * It is linked to this package, so that you can use the transport features as well.
+ * This makes it possible to e.g. directly parse JSON inside the fetch() function.
+ *
+ * @template InstanceData
+ * @template InstanceTransportRequest
+ * @template InstanceTransportResponse
+ */
+final class FetchClient
+{
+    /**
+     * @var FetchConfig<InstanceData, InstanceTransportRequest, InstanceTransportResponse>|null
+     */
+    private ?FetchConfig $config;
+
+    /**
+     * @param FetchConfig<InstanceData, InstanceTransportRequest, InstanceTransportResponse>|null $config
+     */
+    private function __construct(
+        ?FetchConfig $config = null
+    ) {
+        $this->config = $config;
+    }
+
+    /**
+     * @pure
+     *
+     * @return self<null, never, never>
+     */
+    public static function default(): self
+    {
+        return new self();
+    }
+
+    /**
+     * @pure
+     *
+     * @template NewInstanceData
+     * @template NewInstanceTransportRequest
+     * @template NewInstanceTransportResponse
+     *
+     * @param FetchConfig<InstanceData, InstanceTransportRequest, InstanceTransportResponse> $config
+     *
+     * @return self<NewInstanceData, NewInstanceTransportRequest, NewInstanceTransportResponse>
+     */
+    public static function configure(FetchConfig $config): self
+    {
+        return new self($config);
+    }
+
+    /**
+     * @template CallTimeData
+     * @template CallTimeTransportRequest
+     * @template CallTimeTransportResponse
+     *
+     * @param FetchConfig<CallTimeData, CallTimeTransportRequest, CallTimeTransportResponse>|null $config
+     *
+     * @return (CallTimeTransportResponse is never
+     *     ? (InstanceTransportResponse is never ? ResponseInterface : InstanceTransportResponse)
+     *     : CallTimeTransportResponse
+     * )
+     */
+    public function __invoke(string $uri, FetchConfig $config = null)
+    {
+        $allConfig = FetchConfig::defaults()->merge($this->config)->merge($config);
+
+        Assert::notNull($allConfig->method, 'Expected an HTTP method to be configured during fetch.');
+        Assert::notNull($allConfig->transport, 'Expected an HTTP transport factory to be configured during fetch.');
+
+        $client = $this->configureClient($allConfig);
+        $transport = ($allConfig->transport)($client);
+        $request = new Request($allConfig->method, $uri, [], $allConfig->data);
+
+        return $transport($request);
+    }
+
+    /**
+     * @template CallTimeData
+     * @template CallTimeTransportRequest
+     * @template CallTimeTransportResponse
+     *
+     * @param FetchConfig<CallTimeData, CallTimeTransportRequest, CallTimeTransportResponse>|null $config
+     *
+     * @return (CallTimeTransportResponse is never
+     *     ? (InstanceTransportResponse is never ? ResponseInterface : InstanceTransportResponse)
+     *     : CallTimeTransportResponse
+     * )
+     */
+    public function get(string $uri, ?FetchConfig $config = null)
+    {
+        return ($this)($uri, $config);
+    }
+
+    /**
+     * @template CallTimeData
+     * @template CallTimeTransportRequest
+     * @template CallTimeTransportResponse
+     *
+     * @param FetchConfig<CallTimeData, CallTimeTransportRequest, CallTimeTransportResponse>|null $config
+     *
+     * @return (CallTimeTransportResponse is never
+     *     ? (InstanceTransportResponse is never ? ResponseInterface : InstanceTransportResponse)
+     *     : CallTimeTransportResponse
+     * )
+     */
+    public function options(string $uri, ?FetchConfig $config = null)
+    {
+        return ($this)($uri, FetchConfig::of(method: 'OPTIONS')->merge($config));
+    }
+
+    /**
+     * @template CallTimeData
+     * @template CallTimeTransportRequest
+     * @template CallTimeTransportResponse
+     *
+     * @param FetchConfig<CallTimeData, CallTimeTransportRequest, CallTimeTransportResponse>|null $config
+     *
+     * @return (CallTimeTransportResponse is never
+     *     ? (InstanceTransportResponse is never ? ResponseInterface : InstanceTransportResponse)
+     *     : CallTimeTransportResponse
+     * )
+     */
+    public function head(string $uri, ?FetchConfig $config = null)
+    {
+        return ($this)($uri, FetchConfig::of(method: 'HEAD')->merge($config));
+    }
+
+    /**
+     * @template CallTimeData
+     * @template CallTimeTransportRequest
+     * @template CallTimeTransportResponse
+     *
+     * @param FetchConfig<CallTimeData, CallTimeTransportRequest, CallTimeTransportResponse>|null $config
+     *
+     * @return (CallTimeTransportResponse is never
+     *     ? (InstanceTransportResponse is never ? ResponseInterface : InstanceTransportResponse)
+     *     : CallTimeTransportResponse
+     * )
+     */
+    public function delete(string $uri, ?FetchConfig $config = null)
+    {
+        return ($this)($uri, FetchConfig::of(method: 'DELETE')->merge($config));
+    }
+
+    /**
+     * @template CallTimeData
+     * @template CallTimeTransportRequest
+     * @template CallTimeTransportResponse
+     *
+     * @param CallTimeData $data
+     * @param FetchConfig<CallTimeData, CallTimeTransportRequest, CallTimeTransportResponse>|null $config
+     *
+     * @return (CallTimeTransportResponse is never
+     *     ? (InstanceTransportResponse is never ? ResponseInterface : InstanceTransportResponse)
+     *     : CallTimeTransportResponse
+     * )
+     */
+    public function post(string $uri, mixed $data = null, ?FetchConfig $config = null)
+    {
+        return ($this)($uri, FetchConfig::of(
+            method: 'POST',
+            data: $data
+        )->merge($config));
+    }
+
+    /**
+     * @template CallTimeData
+     * @template CallTimeTransportRequest
+     * @template CallTimeTransportResponse
+     *
+     * @param CallTimeData $data
+     * @param FetchConfig<CallTimeData, CallTimeTransportRequest, CallTimeTransportResponse>|null $config
+     *
+     * @return (CallTimeTransportResponse is never
+     *     ? (InstanceTransportResponse is never ? ResponseInterface : InstanceTransportResponse)
+     *     : CallTimeTransportResponse
+     * )
+     */
+    public function put(string $uri, mixed $data = null, ?FetchConfig $config = null)
+    {
+        return ($this)($uri, FetchConfig::of(
+            method: 'PUT',
+            data: $data
+        )->merge($config));
+    }
+
+    /**
+     * @template CallTimeData
+     * @template CallTimeTransportRequest
+     * @template CallTimeTransportResponse
+     *
+     * @param CallTimeData $data
+     * @param FetchConfig<CallTimeData, CallTimeTransportRequest, CallTimeTransportResponse>|null $config
+     *
+     * @return (CallTimeTransportResponse is never
+     *     ? (InstanceTransportResponse is never ? ResponseInterface : InstanceTransportResponse)
+     *     : CallTimeTransportResponse
+     * )
+     */
+    public function patch(string $uri, mixed $data = null, ?FetchConfig $config = null)
+    {
+        return ($this)($uri, FetchConfig::of(
+            method: 'PATCH',
+            data: $data
+        )->merge($config));
+    }
+
+    private function configureClient(FetchConfig $config): ClientInterface
+    {
+        Assert::notNull($config->client, 'Expected an HTTP client to be configured during fetch.');
+
+        return new PluginClient(
+            $config->client,
+            [
+                new ErrorPlugin(),
+                ...($config->headers ? [new HeaderSetPlugin($config->headers)] : []),
+                ...$config->plugins,
+            ]
+        );
+    }
+}

--- a/src/Client/FetchConfig.php
+++ b/src/Client/FetchConfig.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Client;
+
+use Http\Client\Common\Plugin;
+use Http\Discovery\Psr18ClientDiscovery;
+use Phpro\HttpTools\Request\RequestInterface;
+use Phpro\HttpTools\Transport\Presets\PsrPreset;
+use Phpro\HttpTools\Transport\TransportInterface;
+use Phpro\HttpTools\Uri\RawUriBuilder;
+
+use function Psl\Dict\merge;
+
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * @template Data
+ * @template TransportRequest
+ * @template TransportResponse
+ *
+ * @psalm-import-type Method from RequestInterface
+ */
+final class FetchConfig
+{
+    /**
+     * @psalm-readonly
+     *
+     * @var Method|null
+     */
+    public ?string $method = null;
+
+    /**
+     * @psalm-readonly
+     *
+     * @var array<string, string>
+     */
+    public array $headers;
+
+    /**
+     * @psalm-readonly
+     *
+     * @var Data
+     */
+    public mixed $data;
+
+    /**
+     * @psalm-readonly
+     *
+     * @var list<Plugin>
+     */
+    public array $plugins;
+
+    /**
+     * @psalm-readonly
+     */
+    public ?ClientInterface $client;
+
+    /**
+     * @var (callable(ClientInterface): TransportInterface<TransportRequest, TransportResponse>)|null
+     */
+    public $transport;
+
+    /**
+     * @param Method|null $method
+     * @param array<string, string> $headers
+     * @param Data $data
+     * @param list<Plugin> $plugins
+     * @param (callable(ClientInterface): TransportInterface<TransportRequest, TransportResponse>)|null $transport
+     */
+    private function __construct(
+        ?string $method = null,
+        array $headers = [],
+        mixed $data = null,
+        array $plugins = [],
+        ?ClientInterface $client = null,
+        $transport = null
+    ) {
+        $this->method = $method;
+        $this->headers = $headers;
+        $this->data = $data;
+        $this->plugins = $plugins;
+        $this->client = $client;
+        $this->transport = $transport;
+    }
+
+    /**
+     * @template NewData
+     * @template NewTransportRequest
+     * @template NewTransportResponse
+     *
+     * @param Method|null $method
+     * @param array<string, string> $headers
+     * @param NewData $data
+     * @param list<Plugin> $plugins
+     * @param (callable(ClientInterface): TransportInterface<NewTransportRequest, NewTransportResponse>)|null $transport
+     *
+     * @return FetchConfig<NewData, NewTransportRequest, NewTransportResponse>
+     */
+    public static function of(
+        ?string $method = null,
+        array $headers = [],
+        mixed $data = null,
+        array $plugins = [],
+        ?ClientInterface $client = null,
+        $transport = null
+    ): self {
+        return new self($method, $headers, $data, $plugins, $client, $transport);
+    }
+
+    /**
+     * @psalm-suppress MixedReturnTypeCoercion
+     *
+     * @return FetchConfig<null, string|null, ResponseInterface>
+     */
+    public static function defaults(): self
+    {
+        return new self(
+            method: 'GET',
+            client: Psr18ClientDiscovery::find(),
+            transport: self::defaultTransport()
+        );
+    }
+
+    /**
+     * @return callable(ClientInterface): TransportInterface<string|null, ResponseInterface>
+     */
+    public static function defaultTransport()
+    {
+        return static fn (ClientInterface $client) => PsrPreset::sync(
+            $client,
+            RawUriBuilder::createWithAutodiscoveredPsrFactories()
+        );
+    }
+
+    /**
+     * @template MergedData
+     * @template MergedTransportRequest
+     * @template MergedTransportResponse
+     *
+     * @param FetchConfig<MergedData, MergedTransportRequest, MergedTransportResponse>|null $config
+     *
+     * @return FetchConfig<
+     *     ($config is null ? Data : (MergedData is null ? Data : MergedData)),
+     *     ($config is null ? TransportRequest : (MergedTransportRequest is mixed ? MergedTransportRequest : TransportRequest)),
+     *     ($config is null ? TransportResponse : (MergedTransportResponse is mixed ? MergedTransportResponse : TransportResponse))
+     * >
+     */
+    public function merge(?FetchConfig $config): self
+    {
+        return new self(
+            method: $config?->method ?? $this->method,
+            headers: merge($this->headers, $config?->headers ?? []),
+            data: $config?->data ?? $this->data,
+            plugins: [...$this->plugins, ...($config?->plugins ?? [])],
+            client: $config?->client ?? $this->client,
+            transport: $config?->transport ?? $this->transport,
+        );
+    }
+}

--- a/src/Encoding/Raw/RawEncoder.php
+++ b/src/Encoding/Raw/RawEncoder.php
@@ -10,7 +10,7 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 
 /**
- * @implements EncoderInterface<string>
+ * @implements EncoderInterface<string|null>
  */
 final class RawEncoder implements EncoderInterface
 {
@@ -29,10 +29,10 @@ final class RawEncoder implements EncoderInterface
     }
 
     /**
-     * @param string $data
+     * @param string|null $data
      */
     public function __invoke(RequestInterface $request, $data): RequestInterface
     {
-        return $request->withBody($this->streamFactory->createStream($data));
+        return $request->withBody($this->streamFactory->createStream($data ?? ''));
     }
 }

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -9,12 +9,14 @@ namespace Phpro\HttpTools\Request;
  *
  * @psalm-immutable
  *
+ * @psalm-import-type Method from RequestInterface
+ *
  * @implements RequestInterface<RequestType>
  */
 final class Request implements RequestInterface
 {
     /**
-     * @var 'DELETE'|'GET'|'PATCH'|'POST'|'PUT'
+     * @var Method
      */
     private string $method;
     private string $uri;
@@ -26,7 +28,7 @@ final class Request implements RequestInterface
     private $body;
 
     /**
-     * @param 'DELETE'|'GET'|'PATCH'|'POST'|'PUT' $method
+     * @param Method $method
      * @param RequestType $body
      */
     public function __construct(string $method, string $uri, array $uriParameters, $body)
@@ -38,7 +40,7 @@ final class Request implements RequestInterface
     }
 
     /**
-     * @return 'DELETE'|'GET'|'PATCH'|'POST'|'PUT'
+     * @return Method
      */
     public function method(): string
     {

--- a/src/Request/RequestInterface.php
+++ b/src/Request/RequestInterface.php
@@ -8,11 +8,13 @@ namespace Phpro\HttpTools\Request;
  * @template BodyType
  *
  * @psalm-immutable
+ *
+ * @psalm-type Method = 'POST'|'GET'|'DELETE'|'PATCH'|'PUT'|'OPTIONS'|'HEAD';
  */
 interface RequestInterface
 {
     /**
-     * @return 'DELETE'|'GET'|'PATCH'|'POST'|'PUT'
+     * @return Method
      */
     public function method(): string;
 

--- a/src/Transport/Presets/PsrPreset.php
+++ b/src/Transport/Presets/PsrPreset.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Transport\Presets;
+
+use Amp\Promise;
+use Http\Client\HttpAsyncClient;
+use Phpro\HttpTools\Encoding\Psr7\ResponseDecoder;
+use Phpro\HttpTools\Encoding\Raw\RawEncoder;
+use Phpro\HttpTools\Transport\EncodedTransportFactory;
+use Phpro\HttpTools\Transport\TransportInterface;
+use Phpro\HttpTools\Uri\UriBuilderInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\ResponseInterface;
+
+final class PsrPreset
+{
+    /**
+     * @return TransportInterface<string|null, ResponseInterface>
+     */
+    public static function sync(
+        ClientInterface $client,
+        UriBuilderInterface $uriBuilder
+    ): TransportInterface {
+        return EncodedTransportFactory::sync(
+            $client,
+            $uriBuilder,
+            RawEncoder::createWithAutodiscoveredPsrFactories(),
+            ResponseDecoder::createWithAutodiscoveredPsrFactories()
+        );
+    }
+
+    /**
+     * @return TransportInterface<string|null, Promise<ResponseInterface>>
+     */
+    public static function async(
+        HttpAsyncClient $client,
+        UriBuilderInterface $uriBuilder
+    ): TransportInterface {
+        return EncodedTransportFactory::async(
+            $client,
+            $uriBuilder,
+            RawEncoder::createWithAutodiscoveredPsrFactories(),
+            ResponseDecoder::createWithAutodiscoveredPsrFactories()
+        );
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools;
+
+use Phpro\HttpTools\Client\FetchClient;
+use Phpro\HttpTools\Client\FetchConfig;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * @template Data
+ * @template TransportRequest
+ * @template TransportResponse
+ *
+ * @param FetchConfig<Data, TransportRequest, TransportResponse>|null $config
+ *
+ * @return (TransportResponse is never ? ResponseInterface : TransportResponse)
+ */
+function fetch(string $uri, ?FetchConfig $config = null)
+{
+    return FetchClient::default()($uri, $config);
+}
+
+/**
+ * @template Data
+ * @template TransportRequest
+ * @template TransportResponse
+ *
+ * @param FetchConfig<Data, TransportRequest, TransportResponse>|null $config
+ *
+ * @return (TransportResponse is never ? ResponseInterface : TransportResponse)
+ */
+function get(string $uri, ?FetchConfig $config = null)
+{
+    return FetchClient::default()->get($uri, $config);
+}
+
+/**
+ * @template Data
+ * @template TransportRequest
+ * @template TransportResponse
+ *
+ * @param FetchConfig<Data, TransportRequest, TransportResponse>|null $config
+ *
+ * @return (TransportResponse is never ? ResponseInterface : TransportResponse)
+ */
+function options(string $uri, ?FetchConfig $config = null)
+{
+    return FetchClient::default()->options($uri, $config);
+}
+
+/**
+ * @template Data
+ * @template TransportRequest
+ * @template TransportResponse
+ *
+ * @param FetchConfig<Data, TransportRequest, TransportResponse>|null $config
+ *
+ * @return (TransportResponse is never ? ResponseInterface : TransportResponse)
+ */
+function head(string $uri, ?FetchConfig $config = null)
+{
+    return FetchClient::default()->head($uri, $config);
+}
+
+/**
+ * @template Data
+ * @template TransportRequest
+ * @template TransportResponse
+ *
+ * @param FetchConfig<Data, TransportRequest, TransportResponse>|null $config
+ *
+ * @return (TransportResponse is never ? ResponseInterface : TransportResponse)
+ */
+function delete(string $uri, ?FetchConfig $config = null)
+{
+    return FetchClient::default()->delete($uri, $config);
+}
+
+/**
+ * @template Data
+ * @template TransportRequest
+ * @template TransportResponse
+ *
+ * @param Data $data
+ * @param FetchConfig<Data, TransportRequest, TransportResponse>|null $config
+ *
+ * @return (TransportResponse is never ? ResponseInterface : TransportResponse)
+ */
+function post(string $uri, mixed $data, ?FetchConfig $config = null)
+{
+    return FetchClient::default()->post($uri, $data, $config);
+}
+
+/**
+ * @template Data
+ * @template TransportRequest
+ * @template TransportResponse
+ *
+ * @param Data $data
+ * @param FetchConfig<Data, TransportRequest, TransportResponse>|null $config
+ *
+ * @return (TransportResponse is never ? ResponseInterface : TransportResponse)
+ */
+function put(string $uri, mixed $data, ?FetchConfig $config = null)
+{
+    return FetchClient::default()->put($uri, $data, $config);
+}
+
+/**
+ * @template Data
+ * @template TransportRequest
+ * @template TransportResponse
+ *
+ * @param Data $data
+ * @param FetchConfig<Data, TransportRequest, TransportResponse>|null $config
+ *
+ * @return (TransportResponse is never ? ResponseInterface : TransportResponse)
+ */
+function patch(string $uri, mixed $data, ?FetchConfig $config = null)
+{
+    return FetchClient::default()->patch($uri, $data, $config);
+}

--- a/static-analysis/Fetch/config.php
+++ b/static-analysis/Fetch/config.php
@@ -1,0 +1,79 @@
+<?php
+
+use Phpro\HttpTools\Client\FetchConfig;
+use Phpro\HttpTools\Transport\Presets\JsonPreset;
+use Phpro\HttpTools\Transport\TransportInterface;
+use Phpro\HttpTools\Uri\RawUriBuilder;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\ResponseInterface;
+
+$jsonTransport = static fn (ClientInterface $client): TransportInterface =>
+    JsonPreset::sync($client, RawUriBuilder::createWithAutodiscoveredPsrFactories());
+$rawTransport = FetchConfig::defaultTransport();
+
+/**
+ * @return FetchConfig<null, never, never>
+ */
+function emptyConfig(): FetchConfig {
+    return FetchConfig::of();
+}
+
+/**
+ * @return FetchConfig<null, never, never>
+ */
+function mergedEmptyConfig(): FetchConfig {
+    return FetchConfig::of()->merge(FetchConfig::of());
+}
+
+/**
+ * @return FetchConfig<null, string|null, ResponseInterface>
+ */
+function defaultTransport(): FetchConfig
+{
+    global $rawTransport;
+
+    return FetchConfig::of(
+        transport: $rawTransport,
+    );
+}
+
+/**
+ * @return FetchConfig<string, string|null, ResponseInterface>
+ */
+function defaultTransportWithData(): FetchConfig
+{
+    global $rawTransport;
+
+    return FetchConfig::of(
+        data: 'hello',
+        transport: $rawTransport,
+    );
+}
+
+/**
+ * @return FetchConfig<array, array|null, array>
+ */
+function mergedWithEmpty(): FetchConfig
+{
+    global $jsonTransport;
+
+    return FetchConfig::of()->merge(FetchConfig::of(
+        data: [],
+        transport: $jsonTransport,
+    ));
+}
+
+/**
+ * @return FetchConfig<array, array|null, array>
+ */
+function mergedWithPreviousType(): FetchConfig
+{
+    global $jsonTransport, $rawTransport;
+
+    return FetchConfig::of(
+        transport: $rawTransport,
+    )->merge(FetchConfig::of(
+        data: [],
+        transport: $jsonTransport,
+    ));
+}

--- a/static-analysis/Fetch/functions.php
+++ b/static-analysis/Fetch/functions.php
@@ -1,0 +1,51 @@
+<?php
+
+use Phpro\HttpTools\Client\FetchConfig;
+use Phpro\HttpTools\Transport\Presets\JsonPreset;
+use Phpro\HttpTools\Transport\TransportInterface;
+use Phpro\HttpTools\Uri\RawUriBuilder;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\ResponseInterface;
+use function Phpro\HttpTools\fetch;
+
+$uri = 'https://swapi.dev/api/people';
+$jsonTransport = static fn (ClientInterface $client): TransportInterface =>
+    JsonPreset::sync($client, RawUriBuilder::createWithAutodiscoveredPsrFactories());
+
+function urlOnly(): ResponseInterface
+{
+    global $uri;
+    return fetch($uri);
+}
+
+function configWithoutDataOrTransport(): ResponseInterface
+{
+    global $uri;
+    return fetch($uri, FetchConfig::of(method: 'OPTIONS'));
+}
+
+function configWithTransport(): array
+{
+    global $uri, $jsonTransport;
+    return fetch($uri, FetchConfig::of(
+        transport: $jsonTransport
+    ));
+}
+
+function configWithTransportAndMatchingData(): array
+{
+    global $uri, $jsonTransport;
+    return fetch($uri, FetchConfig::of(
+        data: [],
+        transport: $jsonTransport
+    ));
+}
+
+function configWithTransportAndInvalidData(): array
+{
+    global $uri, $jsonTransport;
+    return fetch($uri, FetchConfig::of(
+        data: 'This is not supported',
+        transport: $jsonTransport
+    ));
+}

--- a/static-analysis/Fetch/instance.php
+++ b/static-analysis/Fetch/instance.php
@@ -1,0 +1,123 @@
+<?php
+
+use Phpro\HttpTools\Client\FetchClient;
+use Phpro\HttpTools\Client\FetchConfig;
+use Phpro\HttpTools\Transport\Presets\JsonPreset;
+use Phpro\HttpTools\Transport\TransportInterface;
+use Phpro\HttpTools\Uri\RawUriBuilder;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\ResponseInterface;
+
+$uri = 'https://swapi.dev/api/people';
+$jsonTransport = static fn (ClientInterface $client): TransportInterface =>
+    JsonPreset::sync($client, RawUriBuilder::createWithAutodiscoveredPsrFactories());
+$rawTransport = FetchConfig::defaultTransport();
+
+/**
+ * @template Data
+ * @template TransportRequest
+ * @template TransportResponse
+ *
+ * @return FetchClient<null, never, never>
+ */
+function checkDefaultInstanceSignature()
+{
+    return FetchClient::default();
+}
+
+/**
+ * @template Data
+ * @template TransportRequest
+ * @template TransportResponse
+ *
+ * @param FetchConfig<Data, TransportRequest, TransportResponse> $config
+ *
+ * @return FetchClient<Data, TransportRequest, TransportResponse>
+ */
+function checkInstanceSignatureWithTransport(FetchConfig $config)
+{
+    return FetchClient::configure($config);
+}
+
+/**
+ * @return FetchClient<array, array|null, array>
+ */
+function checkInstanceSignatureWithConfiguredTransport()
+{
+    global $jsonTransport;
+    return FetchClient::configure(FetchConfig::of(
+        transport: $jsonTransport,
+        data: []
+    ));
+}
+
+/**
+ * @return FetchClient<null, never, never>
+ */
+function checkInstanceSignatureWithEmptyConfig()
+{
+    return FetchClient::configure(FetchConfig::of());
+}
+
+function urlOnly(): ResponseInterface
+{
+    global $uri;
+    return FetchClient::default()($uri);
+}
+
+function configWithoutDataOrTransport(): ResponseInterface
+{
+    global $uri;
+    return FetchClient::default()($uri, FetchConfig::of(method: 'OPTIONS'));
+}
+
+function configWithTransport(): array
+{
+    global $uri, $jsonTransport;
+    return FetchClient::default()($uri, FetchConfig::of(
+        transport: $jsonTransport,
+    ));
+}
+
+function configWithTransportAndMatchingData(): array
+{
+    global $uri, $jsonTransport;
+    return FetchClient::default()($uri, FetchConfig::of(
+        data: [],
+        transport: $jsonTransport,
+    ));
+}
+
+function configWithTransportAndInvalidData(): array
+{
+    global $uri, $jsonTransport;
+    return FetchClient::default()($uri, FetchConfig::of(
+        data: 'This is not supported',
+        transport: $jsonTransport,
+    ));
+}
+
+function instanceTransport(): array
+{
+    global $uri, $jsonTransport;
+    return FetchClient::configure(
+        FetchConfig::of(
+            transport: $jsonTransport,
+        )
+    )($uri, FetchConfig::of(
+        data: [],
+    ));
+}
+
+function instanceAndCallTimeTransport(): array
+{
+    global $uri, $rawTransport, $jsonTransport;
+    return FetchClient::configure(
+        FetchConfig::of(
+            transport: $rawTransport,
+        )
+    )($uri, FetchConfig::of(
+        data: [],
+        transport: $jsonTransport,
+    ));
+}

--- a/test.php
+++ b/test.php
@@ -1,0 +1,78 @@
+<?php
+
+use GuzzleHttp\Client;
+use Http\Client\Common\Plugin\LoggerPlugin;
+use Http\Message\Formatter\FullHttpMessageFormatter;
+use Phpro\HttpTools\Client\FetchConfig;
+use Phpro\HttpTools\Transport\Presets\JsonPreset;
+use Phpro\HttpTools\Uri\RawUriBuilder;
+use Psr\Http\Client\ClientInterface;
+use Psr\Log\LoggerInterface;
+use function Phpro\HttpTools\config;
+use function Phpro\HttpTools\fetch;
+
+require_once 'vendor/autoload.php';
+
+$logger = new class() implements LoggerInterface {
+    public function emergency($message, array $context = [])
+    {
+        echo $message;
+    }
+
+    public function alert($message, array $context = [])
+    {
+        echo $message;
+    }
+
+    public function critical($message, array $context = [])
+    {
+        echo $message;
+    }
+
+    public function error($message, array $context = [])
+    {
+        echo $message;
+    }
+
+    public function warning($message, array $context = [])
+    {
+        echo $message;
+    }
+
+    public function notice($message, array $context = [])
+    {
+        echo $message;
+    }
+
+    public function info($message, array $context = [])
+    {
+        echo $message;
+    }
+
+    public function debug($message, array $context = [])
+    {
+        echo $message;
+    }
+
+    public function log($level, $message, array $context = [])
+    {
+        echo $message;
+    }
+};
+
+
+$response = fetch('https://swapi.dev/api/people', FetchConfig::of(
+    headers: [
+        'Accept-Language' => 'nl_BE'
+    ],
+    client: new Client([
+        'verify' => false,
+    ]),
+    transport: fn(ClientInterface $client) =>
+        JsonPreset::sync($client, RawUriBuilder::createWithAutodiscoveredPsrFactories()),
+    plugins: [
+        new LoggerPlugin($logger, new FullHttpMessageFormatter())
+    ]
+));
+
+var_dump($response);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues |

#### Summary

Sometimes you just want to grab something from the interwebz...
This PR introduces an API similar to Javascript's [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch) and shortcut aliases like the [axios package](https://axios-http.com/docs/api_intro).

It is built on top of the transport system, so that you can quickly transform json or deserialize the result into objects.
By default, it uses the new `PsrPreset::sync()`, which accepts a raw string as data and returns a PSR-7 Response.

**Example usage:**

```php
$response = fetch('https://swapi.dev/api/people', [
    'headers' => [
        'Accept-Language' => 'nl_BE'
    ],
    'transport' => fn(ClientInterface $client) =>
        JsonPreset::sync($client, RawUriBuilder::createWithAutodiscoveredPsrFactories())
]);

var_dump($response);
```

Functions:

 * fetch(url[, config])
 * get(url[, config])
 * delete(url[, config])
 * head(url[, config])
 * options(url[, config])
 * post(url[, data[, config]])
 * put(url[, data[, config]])
 * patch(url[, data[, config]])

TODO:

- [ ] Tests
- [ ] Better parameter types for optional data / configs / ...
- [ ] Satic analysis improvements
