### PR TITLE
Introduce a BinaryFile decoder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "require": {
         "php": "~8.1.0 || ~8.2.0",
         "ext-json": "*",
-        "azjezz/psl": "^2.4",
+        "azjezz/psl": "^2.5",
+        "cardinalby/content-disposition": "^1.1",
         "league/uri": "^7.3",
         "php-http/client-common": "^2.7",
         "php-http/discovery": "^1.19",
@@ -30,6 +31,7 @@
         "psr/http-message": "^1.0 || ^2.0",
         "psr/http-message-implementation": "^1.0",
         "psr/log": "^3",
+        "symfony/mime": "^6.3",
         "webmozart/assert": "^1.11"
     },
     "require-dev": {

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -27,26 +27,29 @@ Examples:
 
 This package contains some frequently used encoders / decoders for you:
 
-| Class | EncodingType<DataType> | Action |
-| --- | --- | --- |
-| `EmptyBodyEncoder` | `EncoderInterface<null>` | Creates epmty request body | 
-| `JsonEncoder` | `EncoderInterface<?array>` | Adds json body and headers to request |
-| `JsonDecoder` | `DecoderInterface<array>` | Converts json response body to array |
-| `StreamEncoder` | `EncoderInterface<StreamInterface>` | Adds PSR-7 Stream as request body |
-| `StreamDecoder` | `DecoderInterface<StreamInterface>` | Returns the PSR-7 Stream as response result |
-| `RawEncoder` | `EncoderInterface<string>` | Adds raw string as request body |
-| `RawDecoder` | `DecoderInterface<string>` | Returns the raw PSR-7 body string as response result |
-| `ResponseDecoder` | `DecoderInterface<ResponseInterface>` | Returns the received PSR-7 response as result |
+| Class               | EncodingType<DataType>                | Action                                                                        |
+|---------------------|---------------------------------------|-------------------------------------------------------------------------------|
+| `EmptyBodyEncoder`  | `EncoderInterface<null>`              | Creates epmty request body                                                    | 
+| `BinaryFileDecoder` | `DecoderInterface<BinaryFile>`        | Parses file information from the HTTP response and returns a `BinaryFile` DTO |
+| `JsonEncoder`       | `EncoderInterface<?array>`            | Adds json body and headers to request                                         |
+| `JsonDecoder`       | `DecoderInterface<array>`             | Converts json response body to array                                          |
+| `StreamEncoder`     | `EncoderInterface<StreamInterface>`   | Adds PSR-7 Stream as request body                                             |
+| `StreamDecoder`     | `DecoderInterface<StreamInterface>`   | Returns the PSR-7 Stream as response result                                   |
+| `RawEncoder`        | `EncoderInterface<string>`            | Adds raw string as request body                                               |
+| `RawDecoder`        | `DecoderInterface<string>`            | Returns the raw PSR-7 body string as response result                          |
+| `ResponseDecoder`   | `DecoderInterface<ResponseInterface>` | Returns the received PSR-7 response as result                                 |
 
 ## Built-in transport presets:
 
 We've composed some of the encodings above into pre-configured transports:
 
 
-| Preset | RequestType | ResponseType |
-| --- | --- | --- |
-| `JsonPreset` | `?array` | `array` |
-| `RawPreset` | `string` | `string` |
+| Preset                 | RequestType | ResponseType        |
+|------------------------|-------------|---------------------|
+| `BinaryDownloadPreset` | `null`      | `BinaryFile`        |
+| `JsonPreset`           | `?array`    | `array`             |
+| `PsrPreset`            | `string`    | `ResponseInterface` |
+| `RawPreset`            | `string`    | `string`            |
 
 ## Creating your own configuration
 

--- a/src/Encoding/Binary/BinaryFile.php
+++ b/src/Encoding/Binary/BinaryFile.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Encoding\Binary;
+
+use Psr\Http\Message\StreamInterface;
+
+final class BinaryFile
+{
+    public function __construct(
+        private readonly StreamInterface $stream,
+        private readonly ?int $fileSizeInBytes,
+        private readonly ?string $mimeType,
+        private readonly ?string $fileName,
+        private readonly ?string $extension,
+        private readonly ?string $hash
+    ) {
+    }
+
+    public function stream(): StreamInterface
+    {
+        return $this->stream;
+    }
+
+    public function fileSizeInBytes(): ?int
+    {
+        return $this->fileSizeInBytes;
+    }
+
+    public function mimeType(): ?string
+    {
+        return $this->mimeType;
+    }
+
+    public function fileName(): ?string
+    {
+        return $this->fileName;
+    }
+
+    public function extension(): ?string
+    {
+        return $this->extension;
+    }
+
+    public function hash(): ?string
+    {
+        return $this->hash;
+    }
+}

--- a/src/Encoding/Binary/BinaryFileDecoder.php
+++ b/src/Encoding/Binary/BinaryFileDecoder.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Encoding\Binary;
+
+use Phpro\HttpTools\Encoding\DecoderInterface;
+use Psl\Hash\Algorithm;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * @implements DecoderInterface<BinaryFile>
+ */
+final class BinaryFileDecoder implements DecoderInterface
+{
+    /**
+     * @var callable(ResponseInterface): ?int
+     */
+    private $sizeExtractor;
+
+    /**
+     * @var callable(ResponseInterface): ?string
+     */
+    private $mimeTypeExtractor;
+
+    /**
+     * @var callable(ResponseInterface): ?string
+     */
+    private $fileNameExtractor;
+
+    /**
+     * @var callable(ResponseInterface): ?string
+     */
+    private $extensionExtractor;
+
+    /**
+     * @var callable(ResponseInterface): ?string
+     */
+    private $hashExtractor;
+
+    /**
+     * @param callable(ResponseInterface): ?int $sizeExtractor
+     * @param callable(ResponseInterface): ?string $mimeTypeExtractor
+     * @param callable(ResponseInterface): ?string $fileNameExtractor
+     * @param callable(ResponseInterface): ?string $extensionExtractor
+     * @param callable(ResponseInterface): ?string $hashExtractor
+     */
+    public function __construct(
+        callable $sizeExtractor,
+        callable $mimeTypeExtractor,
+        callable $fileNameExtractor,
+        callable $extensionExtractor,
+        callable $hashExtractor
+    ) {
+        $this->sizeExtractor = $sizeExtractor;
+        $this->mimeTypeExtractor = $mimeTypeExtractor;
+        $this->fileNameExtractor = $fileNameExtractor;
+        $this->extensionExtractor = $extensionExtractor;
+        $this->hashExtractor = $hashExtractor;
+    }
+
+    public static function createWithAutodiscoveredPsrFactories(): self
+    {
+        return new self(
+            new Extractor\SizeExtractor(),
+            new Extractor\MimeTypeExtractor(),
+            new Extractor\FilenameExtractor(),
+            new Extractor\ExtensionExtractor(),
+            new Extractor\HashExtractor(Algorithm::MD5),
+        );
+    }
+
+    public function __invoke(ResponseInterface $response): BinaryFile
+    {
+        return new BinaryFile(
+            $response->getBody(),
+            ($this->sizeExtractor)($response),
+            ($this->mimeTypeExtractor)($response),
+            ($this->fileNameExtractor)($response),
+            ($this->extensionExtractor)($response),
+            ($this->hashExtractor)($response),
+        );
+    }
+}

--- a/src/Encoding/Binary/Extractor/ExtensionExtractor.php
+++ b/src/Encoding/Binary/Extractor/ExtensionExtractor.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Encoding\Binary\Extractor;
+
+use function Psl\Iter\first;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Mime\MimeTypes;
+
+final class ExtensionExtractor
+{
+    public function __invoke(ResponseInterface $response): ?string
+    {
+        if ($mimeType = (new MimeTypeExtractor())($response)) {
+            $extensions = MimeTypes::getDefault()->getExtensions($mimeType);
+            if ($extensions) {
+                return first($extensions);
+            }
+        }
+
+        if ($originalName = (new FilenameExtractor())($response)) {
+            return pathinfo($originalName, PATHINFO_EXTENSION) ?: null;
+        }
+
+        return null;
+    }
+}

--- a/src/Encoding/Binary/Extractor/FilenameExtractor.php
+++ b/src/Encoding/Binary/Extractor/FilenameExtractor.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Encoding\Binary\Extractor;
+
+use cardinalby\ContentDisposition\ContentDisposition;
+
+use function Psl\Iter\first;
+use function Psl\Result\try_catch;
+
+use Psr\Http\Message\ResponseInterface;
+
+final class FilenameExtractor
+{
+    public function __invoke(ResponseInterface $response): ?string
+    {
+        if (!$disposition = first($response->getHeader('Content-Disposition'))) {
+            return null;
+        }
+
+        return try_catch(
+            static fn () => ContentDisposition::parse($disposition)->getFilename(),
+            static fn () => null
+        );
+    }
+}

--- a/src/Encoding/Binary/Extractor/HashExtractor.php
+++ b/src/Encoding/Binary/Extractor/HashExtractor.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Encoding\Binary\Extractor;
+
+use Psl\Hash\Algorithm;
+use Psl\Hash\Context;
+use Psr\Http\Message\ResponseInterface;
+
+final class HashExtractor
+{
+    public function __construct(
+        private readonly Algorithm $algorithm
+    ) {
+    }
+
+    public function __invoke(ResponseInterface $response): string
+    {
+        $body = $response->getBody();
+
+        $pos = $body->tell();
+        if ($pos > 0) {
+            $body->rewind();
+        }
+
+        $context = Context::forAlgorithm($this->algorithm);
+        while (!$body->eof()) {
+            $context = $context->update($body->read(1048576));
+        }
+
+        $body->seek($pos);
+
+        return $context->finalize();
+    }
+}

--- a/src/Encoding/Binary/Extractor/MimeTypeExtractor.php
+++ b/src/Encoding/Binary/Extractor/MimeTypeExtractor.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Encoding\Binary\Extractor;
+
+use function Psl\Iter\first;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Mime\MimeTypes;
+
+final class MimeTypeExtractor
+{
+    public function __invoke(ResponseInterface $response): ?string
+    {
+        if ($contentType = first($response->getHeader('Content-Type'))) {
+            return $contentType;
+        }
+
+        if ($originalName = (new FilenameExtractor())($response)) {
+            if ($extension = pathinfo($originalName, PATHINFO_EXTENSION)) {
+                $mimeTypes = MimeTypes::getDefault()->getMimeTypes($extension);
+
+                return first($mimeTypes);
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Encoding/Binary/Extractor/SizeExtractor.php
+++ b/src/Encoding/Binary/Extractor/SizeExtractor.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Encoding\Binary\Extractor;
+
+use function Psl\Iter\first;
+use function Psl\Result\try_catch;
+use function Psl\Type\int;
+
+use Psr\Http\Message\ResponseInterface;
+
+final class SizeExtractor
+{
+    public function __invoke(ResponseInterface $response): ?int
+    {
+        $size = $response->getBody()->getSize();
+        if (null !== $size) {
+            return $size;
+        }
+
+        if ($length = first($response->getHeader('Content-Length'))) {
+            return try_catch(
+                static fn () => int()->coerce($length),
+                static fn () => null
+            );
+        }
+
+        return null;
+    }
+}

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -9,12 +9,14 @@ namespace Phpro\HttpTools\Request;
  *
  * @psalm-immutable
  *
+ * @psalm-import-type Method from RequestInterface
+ *
  * @implements RequestInterface<RequestType>
  */
 final class Request implements RequestInterface
 {
     /**
-     * @var 'DELETE'|'GET'|'PATCH'|'POST'|'PUT'
+     * @var Method
      */
     private string $method;
     private string $uri;
@@ -26,7 +28,7 @@ final class Request implements RequestInterface
     private $body;
 
     /**
-     * @param 'DELETE'|'GET'|'PATCH'|'POST'|'PUT' $method
+     * @param Method $method
      * @param RequestType $body
      */
     public function __construct(string $method, string $uri, array $uriParameters, $body)
@@ -38,7 +40,7 @@ final class Request implements RequestInterface
     }
 
     /**
-     * @return 'DELETE'|'GET'|'PATCH'|'POST'|'PUT'
+     * @return Method
      */
     public function method(): string
     {

--- a/src/Request/RequestInterface.php
+++ b/src/Request/RequestInterface.php
@@ -8,11 +8,13 @@ namespace Phpro\HttpTools\Request;
  * @template BodyType
  *
  * @psalm-immutable
+ *
+ * @psalm-type Method = 'POST'|'GET'|'DELETE'|'PATCH'|'PUT'|'OPTIONS'|'HEAD';
  */
 interface RequestInterface
 {
     /**
-     * @return 'DELETE'|'GET'|'PATCH'|'POST'|'PUT'
+     * @return Method
      */
     public function method(): string;
 

--- a/src/Transport/Presets/BinaryDownloadPreset.php
+++ b/src/Transport/Presets/BinaryDownloadPreset.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Transport\Presets;
+
+use Phpro\HttpTools\Encoding\Binary\BinaryFile;
+use Phpro\HttpTools\Encoding\Binary\BinaryFileDecoder;
+use Phpro\HttpTools\Encoding\Raw\EmptyBodyEncoder;
+use Phpro\HttpTools\Transport\EncodedTransportFactory;
+use Phpro\HttpTools\Transport\TransportInterface;
+use Phpro\HttpTools\Uri\UriBuilderInterface;
+use Psr\Http\Client\ClientInterface;
+
+final class BinaryDownloadPreset
+{
+    /**
+     * @return TransportInterface<null, BinaryFile>
+     */
+    public static function create(
+        ClientInterface $client,
+        UriBuilderInterface $uriBuilder
+    ): TransportInterface {
+        return EncodedTransportFactory::create(
+            $client,
+            $uriBuilder,
+            EmptyBodyEncoder::createWithAutodiscoveredPsrFactories(),
+            BinaryFileDecoder::createWithAutodiscoveredPsrFactories()
+        );
+    }
+}

--- a/src/Transport/Presets/PsrPreset.php
+++ b/src/Transport/Presets/PsrPreset.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Transport\Presets;
+
+use Phpro\HttpTools\Encoding\Psr7\ResponseDecoder;
+use Phpro\HttpTools\Encoding\Raw\RawEncoder;
+use Phpro\HttpTools\Transport\EncodedTransportFactory;
+use Phpro\HttpTools\Transport\TransportInterface;
+use Phpro\HttpTools\Uri\UriBuilderInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\ResponseInterface;
+
+final class PsrPreset
+{
+    /**
+     * @return TransportInterface<string, ResponseInterface>
+     */
+    public static function create(
+        ClientInterface $client,
+        UriBuilderInterface $uriBuilder
+    ): TransportInterface {
+        return EncodedTransportFactory::create(
+            $client,
+            $uriBuilder,
+            RawEncoder::createWithAutodiscoveredPsrFactories(),
+            ResponseDecoder::createWithAutodiscoveredPsrFactories()
+        );
+    }
+}

--- a/tests/Unit/Encoding/Binary/BinaryFileDecoderTest.php
+++ b/tests/Unit/Encoding/Binary/BinaryFileDecoderTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Tests\Unit\Encoding\Binary;
+
+use Phpro\HttpTools\Encoding\Binary\BinaryFile;
+use Phpro\HttpTools\Encoding\Binary\BinaryFileDecoder;
+use Phpro\HttpTools\Test\UseHttpFactories;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+
+final class BinaryFileDecoderTest extends TestCase
+{
+    use UseHttpFactories;
+
+    /**
+     * @test
+     *
+     * @dataProvider provideCases
+     */
+    public function it_can_decode_binary_files(
+        BinaryFileDecoder $decoder,
+        ResponseInterface $response,
+        BinaryFile $expected
+    ): void {
+        $actual = $decoder($response);
+
+        self::assertSame($actual->stream(), $expected->stream());
+        self::assertSame($actual->fileSizeInBytes(), $expected->fileSizeInBytes());
+        self::assertSame($actual->mimeType(), $expected->mimeType());
+        self::assertSame($actual->fileName(), $expected->fileName());
+        self::assertSame($actual->extension(), $expected->extension());
+    }
+
+    public function provideCases()
+    {
+        $defaultDecoder = BinaryFileDecoder::createWithAutodiscoveredPsrFactories();
+
+        yield 'from-empty-response' => [
+            $defaultDecoder,
+            $response = $this->createResponse(),
+            new BinaryFile(
+                $response->getBody(), 0, null, null, null, md5('')
+            ),
+        ];
+        yield 'from-full-response' => [
+            $defaultDecoder,
+            $response = $this->createResponse()
+                ->withBody($this->createStream('12345'))
+                ->withHeader('Content-Type', 'image/jpeg')
+                ->withHeader('Content-Disposition', 'inline; filename="hello.jpg"'),
+            new BinaryFile(
+                $response->getBody(), 5, 'image/jpeg', 'hello.jpg', 'jpg', md5('12345')
+            ),
+        ];
+        yield 'from-configurable-extractors' => [
+            new BinaryFileDecoder(
+                fn () => 5,
+                fn () => 'image/jpeg',
+                fn () => 'hello.jpg',
+                fn () => 'jpg',
+                fn () => 'md5',
+            ),
+            $response = $this->createResponse(),
+            new BinaryFile(
+                $response->getBody(), 5, 'image/jpeg', 'hello.jpg', 'jpg', 'md5'
+            ),
+        ];
+    }
+}

--- a/tests/Unit/Encoding/Binary/BinaryFileTest.php
+++ b/tests/Unit/Encoding/Binary/BinaryFileTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Tests\Unit\Encoding\Binary;
+
+use Phpro\HttpTools\Encoding\Binary\BinaryFile;
+use Phpro\HttpTools\Test\UseHttpFactories;
+use PHPUnit\Framework\TestCase;
+
+final class BinaryFileTest extends TestCase
+{
+    use UseHttpFactories;
+
+    /** @test */
+    public function it_is_a_dto(): void
+    {
+        $dto = new BinaryFile(
+            $stream = $this->createStream(''),
+            $fileInBytes = 5,
+            $mimeType = 'mime',
+            $fileName = 'hello.jpg',
+            $extension = 'jpg',
+            $hash = 'md5'
+        );
+
+        self::assertSame($stream, $dto->stream());
+        self::assertSame($fileInBytes, $dto->fileSizeInBytes());
+        self::assertSame($mimeType, $dto->mimeType());
+        self::assertSame($fileName, $dto->fileName());
+        self::assertSame($extension, $dto->extension());
+        self::assertSame($hash, $dto->hash());
+    }
+}

--- a/tests/Unit/Encoding/Binary/Extractor/ExtensionExtractorTest.php
+++ b/tests/Unit/Encoding/Binary/Extractor/ExtensionExtractorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Tests\Unit\Encoding\Binary\Extractor;
+
+use Phpro\HttpTools\Encoding\Binary\Extractor\ExtensionExtractor;
+use Phpro\HttpTools\Test\UseHttpFactories;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+
+final class ExtensionExtractorTest extends TestCase
+{
+    use UseHttpFactories;
+
+    /**
+     * @test
+     *
+     * @dataProvider provideCases
+     */
+    public function it_can_extract_extension(ResponseInterface $response, ?string $expected): void
+    {
+        $extractor = new ExtensionExtractor();
+        $actual = $extractor($response);
+
+        self::assertSame($actual, $expected);
+    }
+
+    public function provideCases()
+    {
+        yield 'from-valid-content-type' => [
+            $this->createResponse()
+                ->withHeader('Content-Type', 'image/jpeg'),
+            'jpg',
+        ];
+        yield 'from-invalid-content-type' => [
+            $this->createResponse()
+                ->withHeader('Content-Type', ['unknown/unkown']),
+            null,
+        ];
+        yield 'filename-with-extension' => [
+            $this->createResponse()
+                ->withHeader('Content-Disposition', 'attachment; filename="hello.jpg"'),
+            'jpg',
+        ];
+        yield 'filename-without-extension-mime-type' => [
+            $this->createResponse()
+                ->withHeader('Content-Disposition', 'attachment; filename="hello"'),
+            null,
+        ];
+        yield 'none' => [
+            $this->createResponse(),
+            null,
+        ];
+    }
+}

--- a/tests/Unit/Encoding/Binary/Extractor/FilenameExtractorTest.php
+++ b/tests/Unit/Encoding/Binary/Extractor/FilenameExtractorTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Tests\Unit\Encoding\Binary\Extractor;
+
+use Phpro\HttpTools\Encoding\Binary\Extractor\FilenameExtractor;
+use Phpro\HttpTools\Test\UseHttpFactories;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+
+final class FilenameExtractorTest extends TestCase
+{
+    use UseHttpFactories;
+
+    /**
+     * @test
+     *
+     * @dataProvider provideCases
+     */
+    public function it_can_extract_filenames(ResponseInterface $response, ?string $expected): void
+    {
+        $extractor = new FilenameExtractor();
+        $actual = $extractor($response);
+
+        self::assertSame($actual, $expected);
+    }
+
+    public function provideCases()
+    {
+        yield 'single-content-disposition' => [
+            $this->createResponse()
+                ->withHeader('Content-Disposition', 'inline; filename=hello.jpg'),
+            'hello.jpg',
+        ];
+        yield 'multiple-content-disposition' => [
+            $this->createResponse()
+                ->withHeader('Content-Disposition', [
+                    'inline; filename=hello.jpg',
+                    'inline; filename=goodbye.jpg',
+                ]),
+            'hello.jpg',
+        ];
+        yield 'filename-ext-content-disposition' => [
+            $this->createResponse()
+                ->withHeader('Content-Disposition', 'attachment; filename="notthis.jpg"; filename*=UTF-8\'\'hello.jpg'),
+            'hello.jpg',
+        ];
+        yield 'invalid-disposition' => [
+            $this->createResponse()
+                ->withHeader('Content-Disposition', 'qsdfqsdfqsdf'),
+            null,
+        ];
+        yield 'none' => [
+            $this->createResponse(),
+            null,
+        ];
+    }
+}

--- a/tests/Unit/Encoding/Binary/Extractor/HashExtractorTest.php
+++ b/tests/Unit/Encoding/Binary/Extractor/HashExtractorTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Tests\Unit\Encoding\Binary\Extractor;
+
+use Phpro\HttpTools\Encoding\Binary\Extractor\HashExtractor;
+use Phpro\HttpTools\Test\UseHttpFactories;
+use PHPUnit\Framework\TestCase;
+use Psl\Hash\Algorithm;
+
+use function Psl\Hash\hash;
+
+use Psr\Http\Message\ResponseInterface;
+
+final class HashExtractorTest extends TestCase
+{
+    use UseHttpFactories;
+
+    /**
+     * @test
+     *
+     * @dataProvider provideCases
+     */
+    public function it_can_extract_hash(ResponseInterface $response, string $expected, int $endPosition = 0): void
+    {
+        $extractor = new HashExtractor(Algorithm::MD5);
+        $actual = $extractor($response);
+
+        self::assertSame($actual, $expected);
+        self::assertSame($endPosition, $response->getBody()->tell());
+    }
+
+    public function provideCases()
+    {
+        yield 'from-empty-stream-size' => [
+            $this->createResponse(),
+            hash('', Algorithm::MD5),
+        ];
+
+        yield 'from-stream-size' => [
+            $this->createResponse()
+                ->withBody(
+                    $this->createStream('12345')
+                ),
+            hash('12345', Algorithm::MD5),
+        ];
+
+        $stream = $this->createStream('12345');
+        $stream->seek(3);
+        yield 'from-partially-read-stream' => [
+            $this->createResponse()
+                ->withBody($stream),
+            hash('12345', Algorithm::MD5),
+            3,
+        ];
+    }
+}

--- a/tests/Unit/Encoding/Binary/Extractor/MimeTypeExtractorTest.php
+++ b/tests/Unit/Encoding/Binary/Extractor/MimeTypeExtractorTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Tests\Unit\Encoding\Binary\Extractor;
+
+use Phpro\HttpTools\Encoding\Binary\Extractor\MimeTypeExtractor;
+use Phpro\HttpTools\Test\UseHttpFactories;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+
+final class MimeTypeExtractorTest extends TestCase
+{
+    use UseHttpFactories;
+
+    /**
+     * @test
+     *
+     * @dataProvider provideCases
+     */
+    public function it_can_extract_mime_type(ResponseInterface $response, ?string $expected): void
+    {
+        $extractor = new MimeTypeExtractor();
+        $actual = $extractor($response);
+
+        self::assertSame($actual, $expected);
+    }
+
+    public function provideCases()
+    {
+        yield 'single-content-type' => [
+            $this->createResponse()
+                ->withHeader('Content-Type', 'image/jpeg'),
+            'image/jpeg',
+        ];
+        yield 'multiple-content-type' => [
+            $this->createResponse()
+                ->withHeader('Content-Type', [
+                    'image/jpeg',
+                    'image/png',
+                ]),
+            'image/jpeg',
+        ];
+        yield 'filename-with-extension-mime-type' => [
+            $this->createResponse()
+                ->withHeader('Content-Disposition', 'attachment; filename="hello.jpg"'),
+            'image/jpeg',
+        ];
+        yield 'filename-without-extension-mime-type' => [
+            $this->createResponse()
+                ->withHeader('Content-Disposition', 'attachment; filename="hello"'),
+            null,
+        ];
+        yield 'filename-with-unknown-extension-mime-type' => [
+            $this->createResponse()
+                ->withHeader('Content-Disposition', 'attachment; filename="hello.thisextensiondoesnotexist";'),
+            null,
+        ];
+        yield 'none' => [
+            $this->createResponse(),
+            null,
+        ];
+    }
+}

--- a/tests/Unit/Encoding/Binary/Extractor/SizeExtractorTest.php
+++ b/tests/Unit/Encoding/Binary/Extractor/SizeExtractorTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Tests\Unit\Encoding\Binary\Extractor;
+
+use Phpro\HttpTools\Encoding\Binary\Extractor\SizeExtractor;
+use Phpro\HttpTools\Test\UseHttpFactories;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+final class SizeExtractorTest extends TestCase
+{
+    use UseHttpFactories;
+
+    /**
+     * @test
+     *
+     * @dataProvider provideCases
+     */
+    public function it_can_extract_size(ResponseInterface $response, ?int $expected): void
+    {
+        $extractor = new SizeExtractor();
+        $actual = $extractor($response);
+
+        self::assertSame($actual, $expected);
+    }
+
+    public function provideCases()
+    {
+        $notSizeableStream = $this->createMock(StreamInterface::class);
+        $notSizeableStream->method('getSize')->willReturn(null);
+
+        yield 'from-empty-stream-size' => [
+            $this->createResponse(),
+            0,
+        ];
+
+        yield 'from-stream-size' => [
+            $this->createResponse()
+                ->withBody($this->createStream('12345')),
+            5,
+        ];
+
+        yield 'from-single-content-length' => [
+            $this->createResponse()
+                ->withBody($notSizeableStream)
+                ->withHeader('Content-Length', '500'),
+            500,
+        ];
+        yield 'from-multiple-content-length' => [
+            $this->createResponse()
+                ->withBody($notSizeableStream)
+                ->withHeader('Content-Length', [
+                    '500',
+                    '600',
+                ]),
+            500,
+        ];
+        yield 'from-invalid-content-length' => [
+            $this->createResponse()
+                ->withBody($notSizeableStream)
+                ->withHeader('Content-Length', 'thisisnotanint'),
+            null,
+        ];
+        yield 'from-no-info-whatsoever' => [
+            $this->createResponse()
+                ->withBody($notSizeableStream),
+            null,
+        ];
+    }
+}

--- a/tests/Unit/Transport/Presets/BinaryDownloadPresetTest.php
+++ b/tests/Unit/Transport/Presets/BinaryDownloadPresetTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Tests\Unit\Transport\Presets;
+
+use Phpro\HttpTools\Encoding\Binary\BinaryFile;
+use Phpro\HttpTools\Test\UseHttpToolsFactories;
+use Phpro\HttpTools\Test\UseMockClient;
+use Phpro\HttpTools\Transport\Presets\BinaryDownloadPreset;
+use Phpro\HttpTools\Uri\RawUriBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class BinaryDownloadPresetTest extends TestCase
+{
+    use UseHttpToolsFactories;
+    use UseMockClient;
+
+    /** @test */
+    public function it_can_create_sync_transport(): void
+    {
+        $transport = BinaryDownloadPreset::create(
+            $client = $this->mockClient(),
+            RawUriBuilder::createWithAutodiscoveredPsrFactories()
+        );
+
+        $request = $this->createToolsRequest('GET', '/api', [], $expectedRequest = '');
+
+        $client->addResponse(
+            $this->createResponse()
+                ->withHeader('Content-Type', $mimeType = 'image/jpeg')
+                ->withHeader('Content-Disposition', 'inline; filename="hello.jpg"')
+                ->withBody($stream = $this->createStream($content = 'world'))
+        );
+
+        $actualResponse = $transport($request);
+        $lastRequest = $client->getLastRequest();
+
+        self::assertSame($expectedRequest, (string) $lastRequest->getBody());
+
+        self::assertInstanceOf(BinaryFile::class, $actualResponse);
+        self::assertSame($stream, $actualResponse->stream());
+        self::assertSame($mimeType, $actualResponse->mimeType());
+        self::assertSame('hello.jpg', $actualResponse->fileName());
+        self::assertSame('jpg', $actualResponse->extension());
+        self::assertSame(md5($content), $actualResponse->hash());
+    }
+}

--- a/tests/Unit/Transport/Presets/PsrPresetTest.php
+++ b/tests/Unit/Transport/Presets/PsrPresetTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Tests\Unit\Transport\Presets;
+
+use Phpro\HttpTools\Test\UseHttpToolsFactories;
+use Phpro\HttpTools\Test\UseMockClient;
+use Phpro\HttpTools\Transport\Presets\PsrPreset;
+use Phpro\HttpTools\Uri\RawUriBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class PsrPresetTest extends TestCase
+{
+    use UseHttpToolsFactories;
+    use UseMockClient;
+
+    /** @test */
+    public function it_can_create_sync_transport(): void
+    {
+        $transport = PsrPreset::create(
+            $client = $this->mockClient(),
+            RawUriBuilder::createWithAutodiscoveredPsrFactories()
+        );
+
+        $request = $this->createToolsRequest('GET', '/api', [], $expectedRequest = 'Hello');
+
+        $client->addResponse(
+            $expectedResponse = $this->createResponse(200)
+                ->withBody($this->createStream('world'))
+        );
+
+        $actualResponse = $transport($request);
+        $lastRequest = $client->getLastRequest();
+
+        self::assertSame($actualResponse, $expectedResponse);
+        self::assertSame($expectedRequest, (string) $lastRequest->getBody());
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | 

#### Summary

Introduces a BinaryFile preset that extracts file information (like content-type, md5 hash, filename, ...) from the response.
That way, all the information you need is already there and you can focus on storing the file and.

```php

use Phpro\HttpTools\Encoding\Binary\BinaryFile;
use Phpro\HttpTools\Request\Request;
use Phpro\HttpTools\Transport\Presets\BinaryDownloadPreset;

$transport = BinaryDownloadPreset::create($client, $uriBuilder);
$binaryFile = $transport(
    new Request('GET', '/some/file', [], null),
);

assert($binaryFile instanceof BinaryFile);
var_dump(
    $binaryFile->stream(),
    $binaryFile->fileSizeInBytes(),
    $binaryFile->hash(),
    $binaryFile->extension(),
    $binaryFile->mimeType(),
    $binaryFile->fileName(),
);
```
