### PR TITLE
Introduce multipart encoder

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -27,17 +27,18 @@ Examples:
 
 This package contains some frequently used encoders / decoders for you:
 
-| Class               | EncodingType<DataType>                | Action                                                                        |
-|---------------------|---------------------------------------|-------------------------------------------------------------------------------|
-| `EmptyBodyEncoder`  | `EncoderInterface<null>`              | Creates epmty request body                                                    | 
-| `BinaryFileDecoder` | `DecoderInterface<BinaryFile>`        | Parses file information from the HTTP response and returns a `BinaryFile` DTO |
-| `JsonEncoder`       | `EncoderInterface<?array>`            | Adds json body and headers to request                                         |
-| `JsonDecoder`       | `DecoderInterface<array>`             | Converts json response body to array                                          |
-| `StreamEncoder`     | `EncoderInterface<StreamInterface>`   | Adds PSR-7 Stream as request body                                             |
-| `StreamDecoder`     | `DecoderInterface<StreamInterface>`   | Returns the PSR-7 Stream as response result                                   |
-| `RawEncoder`        | `EncoderInterface<string>`            | Adds raw string as request body                                               |
-| `RawDecoder`        | `DecoderInterface<string>`            | Returns the raw PSR-7 body string as response result                          |
-| `ResponseDecoder`   | `DecoderInterface<ResponseInterface>` | Returns the received PSR-7 response as result                                 |
+| Class               | EncodingType<DataType>                | Action                                                                              |
+|---------------------|---------------------------------------|-------------------------------------------------------------------------------------|
+| `EmptyBodyEncoder`  | `EncoderInterface<null>`              | Creates epmty request body                                                          | 
+| `BinaryFileDecoder` | `DecoderInterface<BinaryFile>`        | Parses file information from the HTTP response and returns a `BinaryFile` DTO       |
+| `JsonEncoder`       | `EncoderInterface<?array>`            | Adds json body and headers to request                                               |
+| `JsonDecoder`       | `DecoderInterface<array>`             | Converts json response body to array                                                |
+| `MultiPartEncoder`     | `EncoderInterface<AbstractMultipartPart>`   | Adds symfony/mime `AbstractMultipartPart`as HTTP body. Handy for form data + files. |
+| `StreamEncoder`     | `EncoderInterface<StreamInterface>`   | Adds PSR-7 Stream as request body                                                   |
+| `StreamDecoder`     | `DecoderInterface<StreamInterface>`   | Returns the PSR-7 Stream as response result                                         |
+| `RawEncoder`        | `EncoderInterface<string>`            | Adds raw string as request body                                                     |
+| `RawDecoder`        | `DecoderInterface<string>`            | Returns the raw PSR-7 body string as response result                                |
+| `ResponseDecoder`   | `DecoderInterface<ResponseInterface>` | Returns the received PSR-7 response as result                                       |
 
 ## Built-in transport presets:
 

--- a/src/Encoding/Mime/MultiPartEncoder.php
+++ b/src/Encoding/Mime/MultiPartEncoder.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Encoding\Mime;
+
+use Http\Discovery\Psr17FactoryDiscovery;
+use Phpro\HttpTools\Encoding\EncoderInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Symfony\Component\Mime\Part\AbstractMultipartPart as MultiPart;
+
+/**
+ * @implements EncoderInterface<MultiPart>
+ */
+final class MultiPartEncoder implements EncoderInterface
+{
+    private StreamFactoryInterface $streamFactory;
+
+    public function __construct(StreamFactoryInterface $streamFactory)
+    {
+        $this->streamFactory = $streamFactory;
+    }
+
+    public static function createWithAutodiscoveredPsrFactories(): self
+    {
+        return new self(
+            Psr17FactoryDiscovery::findStreamFactory()
+        );
+    }
+
+    /**
+     * @param MultiPart $data
+     */
+    public function __invoke(RequestInterface $request, $data): RequestInterface
+    {
+        return $request
+            ->withAddedHeader(
+                'Content-Type',
+                (string) ($data->getHeaders()->getHeaderBody('Content-Type') ?? 'multipart/form-data')
+            )
+            ->withBody($this->streamFactory->createStream(
+                $data->bodyToString()
+            ));
+    }
+}

--- a/tests/Unit/Encoding/Mime/MultiPartEncoderTest.php
+++ b/tests/Unit/Encoding/Mime/MultiPartEncoderTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Tests\Unit\Encoding\Mime;
+
+use Phpro\HttpTools\Encoding\Mime\MultiPartEncoder;
+use Phpro\HttpTools\Test\UseHttpFactories;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mime\Part\DataPart;
+use Symfony\Component\Mime\Part\Multipart\FormDataPart;
+
+final class MultiPartEncoderTest extends TestCase
+{
+    use UseHttpFactories;
+
+    /** @test */
+    public function it_can_encode_multi_part(): void
+    {
+        $data = new FormDataPart([
+            'name' => 'Jos Bos',
+            'profilePic' => DataPart::fromPath(__FILE__, 'rce-pic.png'),
+        ]);
+
+        $encoder = MultiPartEncoder::createWithAutodiscoveredPsrFactories();
+        $request = $this->createRequest('POST', '/hello');
+
+        $actual = $encoder($request, $data);
+
+        self::assertSame($request->getMethod(), $actual->getMethod());
+        self::assertSame($request->getUri(), $actual->getUri());
+        self::assertSame($data->bodyToString(), (string) $actual->getBody());
+        self::assertSame(['multipart/form-data'], $actual->getHeader('Content-Type'));
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | 

#### Summary

This PR allows for sending multipart form messages, uploads, mixed multi-parts, ... based on the parts available inside `symfony/mime`.

```php
use Phpro\HttpTools\Encoding\Json\JsonDecoder;
use Phpro\HttpTools\Encoding\Mime\MultiPartEncoder;
use Phpro\HttpTools\Transport\EncodedTransportFactory;
use Symfony\Component\Mime\Part\DataPart;
use Symfony\Component\Mime\Part\Multipart\FormDataPart;
use Phpro\HttpTools\Request\Request;

$transport = EncodedTransportFactory::create(
    $client,
    $uriBuilder,
    MultiPartEncoder::createWithAutodiscoveredPsrFactories(),
    JsonDecoder::createWithAutodiscoveredPsrFactories()
);

$jsonData = $transport(
    new Request('GET', '/some/file', [], new FormDataPart([
        'name' => 'Jos bos',
        'profile-pic' => DataPart::fromPath('/my-profile-pic.jpg')
    ])),
);
```


If you wish not to use `symfony/mime` for this, you could use `guzzle/psr7`'s `MultipartStream` with the existing `StreamEncoder` option:
