### PR TITLE
Introduce form urlencoded transport

### DIFF
--- a/.github/workflows/grumphp.yaml
+++ b/.github/workflows/grumphp.yaml
@@ -29,7 +29,7 @@ jobs:
               id: composercache
               run: echo "::set-output name=dir::$(composer config cache-files-dir)"
             - name: Cache dependencies
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                   path: ${{ steps.composercache.outputs.dir }}
                   key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -27,18 +27,20 @@ Examples:
 
 This package contains some frequently used encoders / decoders for you:
 
-| Class               | EncodingType<DataType>                | Action                                                                              |
-|---------------------|---------------------------------------|-------------------------------------------------------------------------------------|
-| `EmptyBodyEncoder`  | `EncoderInterface<null>`              | Creates epmty request body                                                          | 
-| `BinaryFileDecoder` | `DecoderInterface<BinaryFile>`        | Parses file information from the HTTP response and returns a `BinaryFile` DTO       |
-| `JsonEncoder`       | `EncoderInterface<?array>`            | Adds json body and headers to request                                               |
-| `JsonDecoder`       | `DecoderInterface<array>`             | Converts json response body to array                                                |
-| `MultiPartEncoder`     | `EncoderInterface<AbstractMultipartPart>`   | Adds symfony/mime `AbstractMultipartPart`as HTTP body. Handy for form data + files. |
-| `StreamEncoder`     | `EncoderInterface<StreamInterface>`   | Adds PSR-7 Stream as request body                                                   |
-| `StreamDecoder`     | `DecoderInterface<StreamInterface>`   | Returns the PSR-7 Stream as response result                                         |
-| `RawEncoder`        | `EncoderInterface<string>`            | Adds raw string as request body                                                     |
-| `RawDecoder`        | `DecoderInterface<string>`            | Returns the raw PSR-7 body string as response result                                |
-| `ResponseDecoder`   | `DecoderInterface<ResponseInterface>` | Returns the received PSR-7 response as result                                       |
+| Class                   | EncodingType<DataType>                | Action                                                                              |
+|-------------------------|---------------------------------------|-------------------------------------------------------------------------------------|
+| `EmptyBodyEncoder`      | `EncoderInterface<null>`              | Creates empty request body                                                          | 
+| `BinaryFileDecoder`     | `DecoderInterface<BinaryFile>`        | Parses file information from the HTTP response and returns a `BinaryFile` DTO       |
+| `FormUrlencodedEncoder` | `EncoderInterface<?array>`            | Adds form urlencoded body and headers to request                                    |
+| `FormUrlencodedDecoder` | `DecoderInterface<array>`             | Converts form urlencoded response body to array                                     |
+| `JsonEncoder`           | `EncoderInterface<?array>`            | Adds json body and headers to request                                               |
+| `JsonDecoder`           | `DecoderInterface<array>`             | Converts json response body to array                                                |
+| `MultiPartEncoder`      | `EncoderInterface<AbstractMultipartPart>`   | Adds symfony/mime `AbstractMultipartPart`as HTTP body. Handy for form data + files. |
+| `StreamEncoder`         | `EncoderInterface<StreamInterface>`   | Adds PSR-7 Stream as request body                                                   |
+| `StreamDecoder`         | `DecoderInterface<StreamInterface>`   | Returns the PSR-7 Stream as response result                                         |
+| `RawEncoder`            | `EncoderInterface<string>`            | Adds raw string as request body                                                     |
+| `RawDecoder`            | `DecoderInterface<string>`            | Returns the raw PSR-7 body string as response result                                |
+| `ResponseDecoder`       | `DecoderInterface<ResponseInterface>` | Returns the received PSR-7 response as result                                       |
 
 ## Built-in transport presets:
 
@@ -49,6 +51,7 @@ We've composed some of the encodings above into pre-configured transports:
 |------------------------|-------------------------|---------------------|------------------------|
 | `BinaryDownloadPreset` | `null`                  | `BinaryFile`        | `withEmptyRequest`     |
 | `BinaryDownloadPreset` | `AbstractMultipartPart` | `BinaryFile`        | `withMultiPartRequest` |
+| `FormUrlencodedPreset` | `?array`                | `array`             | `create`               |
 | `JsonPreset`           | `?array`                | `array`             | `create`               |
 | `PsrPreset`            | `string`                | `ResponseInterface` | `create`               |
 | `RawPreset`            | `string`                | `string`            | `create`               |

--- a/src/Encoding/FormUrlencoded/FormUrlencodedDecoder.php
+++ b/src/Encoding/FormUrlencoded/FormUrlencodedDecoder.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Encoding\FormUrlencoded;
+
+use Phpro\HttpTools\Encoding\DecoderInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * @implements DecoderInterface<array>
+ */
+final class FormUrlencodedDecoder implements DecoderInterface
+{
+    public static function createWithAutodiscoveredPsrFactories(): self
+    {
+        return new self();
+    }
+
+    public function __invoke(ResponseInterface $response): array
+    {
+        if (!$responseBody = (string) $response->getBody()) {
+            return [];
+        }
+
+        parse_str($responseBody, $output);
+
+        return $output;
+    }
+}

--- a/src/Encoding/FormUrlencoded/FormUrlencodedEncoder.php
+++ b/src/Encoding/FormUrlencoded/FormUrlencodedEncoder.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Encoding\FormUrlencoded;
+
+use Http\Discovery\Psr17FactoryDiscovery;
+
+use const PHP_QUERY_RFC1738;
+
+use Phpro\HttpTools\Encoding\EncoderInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+/**
+ * @implements EncoderInterface<array|null>
+ */
+final class FormUrlencodedEncoder implements EncoderInterface
+{
+    private StreamFactoryInterface $streamFactory;
+
+    public function __construct(StreamFactoryInterface $streamFactory)
+    {
+        $this->streamFactory = $streamFactory;
+    }
+
+    public static function createWithAutodiscoveredPsrFactories(): self
+    {
+        return new self(
+            Psr17FactoryDiscovery::findStreamFactory()
+        );
+    }
+
+    /**
+     * @param array|null $data
+     */
+    public function __invoke(RequestInterface $request, $data): RequestInterface
+    {
+        return $request
+            ->withAddedHeader('Content-Type', 'application/x-www-form-urlencoded')
+            ->withBody($this->streamFactory->createStream(
+                null !== $data ? http_build_query($data, encoding_type: PHP_QUERY_RFC1738) : ''
+            ));
+    }
+}

--- a/src/Transport/Presets/FormUrlencodedPreset.php
+++ b/src/Transport/Presets/FormUrlencodedPreset.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Transport\Presets;
+
+use Phpro\HttpTools\Encoding\DecoderInterface;
+use Phpro\HttpTools\Encoding\FormUrlencoded\FormUrlencodedDecoder;
+use Phpro\HttpTools\Encoding\FormUrlencoded\FormUrlencodedEncoder;
+use Phpro\HttpTools\Transport\EncodedTransportFactory;
+use Phpro\HttpTools\Transport\TransportInterface;
+use Phpro\HttpTools\Uri\UriBuilderInterface;
+use Psr\Http\Client\ClientInterface;
+
+final class FormUrlencodedPreset
+{
+    /**
+     * @param DecoderInterface<array>|null $decoder
+     *
+     * @return TransportInterface<array|null, array>
+     */
+    public static function create(
+        ClientInterface $client,
+        UriBuilderInterface $uriBuilder,
+        ?DecoderInterface $decoder = null,
+    ): TransportInterface {
+        return EncodedTransportFactory::create(
+            $client,
+            $uriBuilder,
+            FormUrlencodedEncoder::createWithAutodiscoveredPsrFactories(),
+            $decoder ?? FormUrlencodedDecoder::createWithAutodiscoveredPsrFactories()
+        );
+    }
+}

--- a/tests/Unit/Encoding/FormUrlencoded/FormUrlencodedDecoderTest.php
+++ b/tests/Unit/Encoding/FormUrlencoded/FormUrlencodedDecoderTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Tests\Unit\Encoding\FormUrlencoded;
+
+use Phpro\HttpTools\Encoding\FormUrlencoded\FormUrlencodedDecoder;
+use Phpro\HttpTools\Test\UseHttpFactories;
+use PHPUnit\Framework\TestCase;
+
+final class FormUrlencodedDecoderTest extends TestCase
+{
+    use UseHttpFactories;
+
+    /** @test */
+    public function it_can_decode_form_url_encoded_to_array(): void
+    {
+        $decoder = FormUrlencodedDecoder::createWithAutodiscoveredPsrFactories();
+        $response = $this->createResponse()
+            ->withBody($this->createStream('hello=world&foo=bar'));
+        $decoded = $decoder($response);
+
+        self::assertSame(['hello' => 'world', 'foo' => 'bar'], $decoded);
+    }
+
+    /** @test */
+    public function it_can_decode_empty_body_to_empty_array(): void
+    {
+        $decoder = FormUrlencodedDecoder::createWithAutodiscoveredPsrFactories();
+        $response = $this->createResponse()->withBody($this->createStream(''));
+        $decoded = $decoder($response);
+
+        self::assertSame([], $decoded);
+    }
+}

--- a/tests/Unit/Encoding/FormUrlencoded/FormUrlencodedEncoderTest.php
+++ b/tests/Unit/Encoding/FormUrlencoded/FormUrlencodedEncoderTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Tests\Unit\Encoding\FormUrlencoded;
+
+use Phpro\HttpTools\Encoding\FormUrlencoded\FormUrlencodedEncoder;
+use Phpro\HttpTools\Test\UseHttpFactories;
+use PHPUnit\Framework\TestCase;
+
+final class FormUrlencodedEncoderTest extends TestCase
+{
+    use UseHttpFactories;
+
+    /** @test */
+    public function it_can_encode_array_to_url_encoded(): void
+    {
+        $data = ['hello' => 'world'];
+        $encoder = FormUrlencodedEncoder::createWithAutodiscoveredPsrFactories();
+        $request = $this->createRequest('POST', '/hello');
+
+        $actual = $encoder($request, $data);
+
+        self::assertSame($request->getMethod(), $actual->getMethod());
+        self::assertSame($request->getUri(), $actual->getUri());
+        self::assertSame('hello=world', (string) $actual->getBody());
+        self::assertSame(['application/x-www-form-urlencoded'], $actual->getHeader('Content-Type'));
+    }
+
+    /** @test */
+    public function it_can_encode_null_to_empty_body(): void
+    {
+        $data = null;
+        $encoder = FormUrlencodedEncoder::createWithAutodiscoveredPsrFactories();
+        $request = $this->createRequest('POST', '/hello');
+
+        $actual = $encoder($request, $data);
+
+        self::assertSame($request->getMethod(), $actual->getMethod());
+        self::assertSame($request->getUri(), $actual->getUri());
+        self::assertSame('', (string) $actual->getBody());
+        self::assertSame(['application/x-www-form-urlencoded'], $actual->getHeader('Content-Type'));
+    }
+}

--- a/tests/Unit/Transport/Presets/FormUrlencodedPresetTest.php
+++ b/tests/Unit/Transport/Presets/FormUrlencodedPresetTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\HttpTools\Tests\Unit\Transport\Presets;
+
+use Phpro\HttpTools\Encoding\Json\JsonDecoder;
+use Phpro\HttpTools\Test\UseHttpToolsFactories;
+use Phpro\HttpTools\Test\UseMockClient;
+use Phpro\HttpTools\Transport\Presets\FormUrlencodedPreset;
+use Phpro\HttpTools\Uri\RawUriBuilder;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psl\Json;
+
+final class FormUrlencodedPresetTest extends TestCase
+{
+    use UseHttpToolsFactories;
+    use UseMockClient;
+
+    /** @test */
+    public function it_can_create_transport(): void
+    {
+        $transport = FormUrlencodedPreset::create(
+            $client = $this->mockClient(),
+            RawUriBuilder::createWithAutodiscoveredPsrFactories()
+        );
+
+        $request = $this->createToolsRequest('GET', '/api', [], $expectedRequest = ['hello' => 'world']);
+
+        $client->addResponse(
+            $this->createResponse(200)
+                ->withBody($this->createStream(
+                    http_build_query($expectedResponse = ['foo' => 'bar']))
+                )
+        );
+
+        $actualResponse = $transport($request);
+        $lastRequest = $client->getLastRequest();
+
+        self::assertSame($actualResponse, $expectedResponse);
+        self::assertSame(http_build_query($expectedRequest), (string) $lastRequest->getBody());
+    }
+
+    #[Test]
+    public function it_is_possible_to_override_specific_decoder(): void
+    {
+        $transport = FormUrlencodedPreset::create(
+            $client = $this->mockClient(),
+            RawUriBuilder::createWithAutodiscoveredPsrFactories(),
+            JsonDecoder::createWithAutodiscoveredPsrFactories(),
+        );
+
+        $request = $this->createToolsRequest('GET', '/api', [], $expectedRequest = ['hello' => 'world']);
+
+        $client->addResponse(
+            $this->createResponse(200)
+                ->withBody($this->createStream(
+                    Json\encode($expectedResponse = ['foo' => 'bar']))
+                )
+        );
+
+        $actualResponse = $transport($request);
+        $lastRequest = $client->getLastRequest();
+
+        self::assertSame($actualResponse, $expectedResponse);
+        self::assertSame(http_build_query($expectedRequest), (string) $lastRequest->getBody());
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues |

#### Summary

This PR introduces form URL-encoded transport functionality to the HttpTools library, enabling applications to work with `application/x-www-form-urlencoded` data format for both encoding requests and decoding responses.

- Adds `FormUrlencodedEncoder` and `FormUrlencodedDecoder` classes for handling form URL-encoded data
- Introduces `FormUrlencodedPreset` as a pre-configured transport for form URL-encoded operations
- Includes comprehensive test coverage for all new components


