### PR TITLE
Replace abandoned azjezz/psl

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
         "ext-json": "*",
-        "azjezz/psl": "^3.1 || ^4.0 || ^5.0",
+        "php-standard-library/php-standard-library": "^3.1 || ^4.0 || ^5.0 || ^6.0",
         "cardinalby/content-disposition": "^1.1",
         "league/uri": "^7.3",
         "php-http/client-common": "^2.7",


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Replace abandoned azjezz/psl with the php-standard-library/php-standard-library package and add version 6.0.
