### PR TITLE
Bump minimum PHP to 8.4, replace monolithic PSL with standalone packages

### DIFF
--- a/.github/workflows/grumphp.yaml
+++ b/.github/workflows/grumphp.yaml
@@ -7,7 +7,7 @@ jobs:
         strategy:
             matrix:
                 operating-system: [ubuntu-latest]
-                php-versions: ['8.3', '8.4', '8.5']
+                php-versions: ['8.4', '8.5']
                 composer-options: ['', '--prefer-lowest']
             fail-fast: false
         name: PHP ${{ matrix.php-versions }} @ ${{ matrix.operating-system }} with ${{ matrix.composer-options }}

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,16 @@
         }
     ],
     "require": {
-        "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
+        "php": "~8.4.0 || ~8.5.0",
         "ext-json": "*",
-        "php-standard-library/php-standard-library": "^3.1 || ^4.0 || ^5.0 || ^6.0",
+        "php-standard-library/foundation": "^6.1",
+        "php-standard-library/fun": "^6.1",
+        "php-standard-library/hash": "^6.1",
+        "php-standard-library/iter": "^6.1",
+        "php-standard-library/json": "^6.1",
+        "php-standard-library/regex": "^6.1",
+        "php-standard-library/result": "^6.1",
+        "php-standard-library/type": "^6.1",
         "cardinalby/content-disposition": "^1.1",
         "league/uri": "^7.3",
         "php-http/client-common": "^2.7",

--- a/psalm.xml
+++ b/psalm.xml
@@ -8,6 +8,7 @@
     findUnusedBaselineEntry="true"
     findUnusedCode="false"
     ensureOverrideAttribute="false"
+    phpVersion="8.4"
 >
     <projectFiles>
         <directory name="src" />


### PR DESCRIPTION
## Summary

- Raises minimum PHP version from `~8.3.0` to `~8.4.0`
- Replaces monolithic `php-standard-library/php-standard-library` with standalone PSL packages (`^6.1`): foundation, fun, hash, iter, json, regex, result, type
- Sets Psalm `phpVersion` to `8.4`

## Validation

- php-cs-fixer: 0 issues
- psalm: no errors
- phpunit: 125 tests, 252 assertions, all passing
- GrumPHP pre-commit: all tasks passed (including 100% clover coverage)

## Notes

No README changes needed; it contains no PHP version references.